### PR TITLE
VCST-1580: add old Xapi module incompatibility

### DIFF
--- a/src/VirtoCommerce.Xapi.Core/Infrastructure/IgnorePlainCoreXapiGraphQLTelemetryProcessor.cs
+++ b/src/VirtoCommerce.Xapi.Core/Infrastructure/IgnorePlainCoreXapiGraphQLTelemetryProcessor.cs
@@ -8,11 +8,11 @@ namespace VirtoCommerce.Xapi.Core.Infrastructure
     /// <summary>
     /// AppInsights telemetry processor that skips default Graphql queries
     /// </summary>
-    public class IgnorePlainGraphQLTelemetryProcessor : ITelemetryProcessor
+    public class IgnorePlainCoreXapiGraphQLTelemetryProcessor : ITelemetryProcessor
     {
         private ITelemetryProcessor Next { get; set; }
 
-        public IgnorePlainGraphQLTelemetryProcessor(ITelemetryProcessor next)
+        public IgnorePlainCoreXapiGraphQLTelemetryProcessor(ITelemetryProcessor next)
         {
             Next = next;
         }

--- a/src/VirtoCommerce.Xapi.Web/Module.cs
+++ b/src/VirtoCommerce.Xapi.Web/Module.cs
@@ -38,7 +38,7 @@ namespace VirtoCommerce.Xapi.Web
 
         public void Initialize(IServiceCollection serviceCollection)
         {
-            serviceCollection.AddApplicationInsightsTelemetryProcessor<IgnorePlainGraphQLTelemetryProcessor>();
+            serviceCollection.AddApplicationInsightsTelemetryProcessor<IgnorePlainCoreXapiGraphQLTelemetryProcessor>();
             // register custom executor with app insight wrapper
             serviceCollection.AddTransient(typeof(IGraphQLExecuter<>), typeof(CustomGraphQLExecuter<>));
             serviceCollection.AddSingleton<IDocumentExecuter, SubscriptionDocumentExecuter>();

--- a/src/VirtoCommerce.Xapi.Web/module.manifest
+++ b/src/VirtoCommerce.Xapi.Web/module.manifest
@@ -12,6 +12,9 @@
     <dependency id="VirtoCommerce.Store" version="3.803.0" />
     <dependency id="VirtoCommerce.Tax" version="3.800.0" />
   </dependencies>
+  <incompatibilities>
+	  <module id="VirtoCommerce.ExperienceApi" version="3.800.0" />
+  </incompatibilities>
 
   <title>Commerce Experience API</title>
   <description>An intermediated layer between clients and enterprise services powered by GraphQL protocol</description>


### PR DESCRIPTION
## Description
![image](https://github.com/user-attachments/assets/3d69043a-a442-4ec8-9679-8579eea17b52)

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-1580
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Xapi_3.802.0-pr-6-8261.zip