### PR TITLE
VCST-1907: Fixed the link to the project repository in the manifest

### DIFF
--- a/src/VirtoCommerce.Xapi.Web/module.manifest
+++ b/src/VirtoCommerce.Xapi.Web/module.manifest
@@ -40,7 +40,7 @@
     <group>commerce</group>
   </groups>
 
-  <projectUrl>https://github.com/VirtoCommerce/vc-module-xapi</projectUrl>
+  <projectUrl>https://github.com/VirtoCommerce/vc-module-x-api</projectUrl>
   <iconUrl>Modules/$(VirtoCommerce.Xapi)/Content/logo.png</iconUrl>
   <requireLicenseAcceptance>false</requireLicenseAcceptance>
 


### PR DESCRIPTION
fix: Fixed the link to the project repository in the module manifest file

## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-1907
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Xapi_3.808.0-pr-12-3744.zip