### PR TITLE
VCST-1867: Mark IsSpa, SubscriptionEnabled and QuotesEnabled as Deprecated

### DIFF
--- a/src/VirtoCommerce.Xapi.Core/Models/StoreSettings.cs
+++ b/src/VirtoCommerce.Xapi.Core/Models/StoreSettings.cs
@@ -5,14 +5,17 @@ namespace VirtoCommerce.Xapi.Core.Models
 {
     public class StoreSettings
     {
+        [Obsolete("Use Quotes.EnableQuotes public property instead", DiagnosticId = "VC0009", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions/")]
         public bool QuotesEnabled { get; set; }
 
+        [Obsolete("Use Subscription.EnableSubscriptions public property instead", DiagnosticId = "VC0009", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions/")]
         public bool SubscriptionEnabled { get; set; }
 
         public bool TaxCalculationEnabled { get; set; }
 
         public bool AnonymousUsersAllowed { get; set; }
 
+        [Obsolete("Client application should use own business logic for SPA detection", DiagnosticId = "VC0009", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions/")]
         public bool IsSpa { get; set; }
 
         public bool EmailVerificationEnabled { get; set; }

--- a/src/VirtoCommerce.Xapi.Core/Models/StoreSettings.cs
+++ b/src/VirtoCommerce.Xapi.Core/Models/StoreSettings.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Identity;
 

--- a/src/VirtoCommerce.Xapi.Core/Schemas/StoreSettingsType.cs
+++ b/src/VirtoCommerce.Xapi.Core/Schemas/StoreSettingsType.cs
@@ -7,11 +7,11 @@ public class StoreSettingsType : ExtendableGraphType<StoreSettings>
 {
     public StoreSettingsType()
     {
-        Field(x => x.QuotesEnabled).Description("Quotes enabled");
-        Field(x => x.SubscriptionEnabled).Description("Store ID");
+        Field(x => x.QuotesEnabled).Description("Quotes enabled").DeprecationReason("Use Quotes.EnableQuotes public property instead.");
+        Field(x => x.SubscriptionEnabled).Description("Subscription enabled").DeprecationReason("Use Subscription.EnableSubscriptions public property instead.");
         Field(x => x.TaxCalculationEnabled).Description("Tax calculation enabled");
         Field(x => x.AnonymousUsersAllowed).Description("Allow anonymous users to visit the store ");
-        Field(x => x.IsSpa).Description("SPA");
+        Field(x => x.IsSpa).Description("SPA").DeprecationReason("Client application should use own business logic for SPA detection.");
         Field(x => x.EmailVerificationEnabled).Description("Email address verification enabled");
         Field(x => x.EmailVerificationRequired).Description("Email address verification required");
         Field(x => x.CreateAnonymousOrderEnabled).Description("Allow anonymous users to create orders (XAPI)");

--- a/src/VirtoCommerce.Xapi.Core/Schemas/StoreSettingsType.cs
+++ b/src/VirtoCommerce.Xapi.Core/Schemas/StoreSettingsType.cs
@@ -7,11 +7,13 @@ public class StoreSettingsType : ExtendableGraphType<StoreSettings>
 {
     public StoreSettingsType()
     {
+#pragma warning disable VC0009
         Field(x => x.QuotesEnabled).Description("Quotes enabled").DeprecationReason("Use Quotes.EnableQuotes public property instead.");
         Field(x => x.SubscriptionEnabled).Description("Subscription enabled").DeprecationReason("Use Subscription.EnableSubscriptions public property instead.");
+        Field(x => x.IsSpa).Description("SPA").DeprecationReason("Client application should use own business logic for SPA detection.");
+#pragma warning restore VC0009
         Field(x => x.TaxCalculationEnabled).Description("Tax calculation enabled");
         Field(x => x.AnonymousUsersAllowed).Description("Allow anonymous users to visit the store ");
-        Field(x => x.IsSpa).Description("SPA").DeprecationReason("Client application should use own business logic for SPA detection.");
         Field(x => x.EmailVerificationEnabled).Description("Email address verification enabled");
         Field(x => x.EmailVerificationRequired).Description("Email address verification required");
         Field(x => x.CreateAnonymousOrderEnabled).Description("Allow anonymous users to create orders (XAPI)");

--- a/src/VirtoCommerce.Xapi.Data/Queries/GetStoreQueryHandler.cs
+++ b/src/VirtoCommerce.Xapi.Data/Queries/GetStoreQueryHandler.cs
@@ -105,7 +105,11 @@ public class GetStoreQueryHandler : IQueryHandler<GetStoreQuery, StoreResponse>
         {
             response.Settings = new StoreSettings
             {
+#pragma warning disable VC0009
                 IsSpa = store.Settings.GetValue<bool>(StoreSettingGeneral.IsSpa),
+                QuotesEnabled = store.Settings.GetValue<bool>(new SettingDescriptor { Name = "Quotes.EnableQuotes" }),
+                SubscriptionEnabled = store.Settings.GetValue<bool>(new SettingDescriptor { Name = "Subscription.EnableSubscriptions" }),
+#pragma warning restore VC0009
                 TaxCalculationEnabled = store.Settings.GetValue<bool>(StoreSettingGeneral.TaxCalculationEnabled),
                 AnonymousUsersAllowed = store.Settings.GetValue<bool>(StoreSettingGeneral.AllowAnonymousUsers),
                 EmailVerificationEnabled = store.Settings.GetValue<bool>(StoreSettingGeneral.EmailVerificationEnabled),
@@ -114,8 +118,6 @@ public class GetStoreQueryHandler : IQueryHandler<GetStoreQuery, StoreResponse>
                 CreateAnonymousOrderEnabled = store.Settings.GetValue<bool>(ModuleConstants.Settings.General.CreateAnonymousOrder),
                 DefaultSelectedForCheckout = store.Settings.GetValue<bool>(ModuleConstants.Settings.General.IsSelectedForCheckout),
 
-                QuotesEnabled = store.Settings.GetValue<bool>(new SettingDescriptor { Name = "Quotes.EnableQuotes" }),
-                SubscriptionEnabled = store.Settings.GetValue<bool>(new SettingDescriptor { Name = "Subscription.EnableSubscriptions" }),
 
                 EnvironmentName = _settingsManager.GetValue<string>(ModuleConstants.Settings.General.EnvironmentName),
                 PasswordRequirements = _identityOptions.Password,


### PR DESCRIPTION
## Description
fix: Mark IsSpa, SubscriptionEnabled and QuotesEnabled as deprecated properties. Use Quotes.EnableQuotes public property instead. Client application should use own business logic for SPA detection. Both properties will be removed after 11 stable release.

## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/VCST-1867
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Xapi_3.810.0-pr-13-bf6c.zip