### PR TITLE
VCST-1932: Set CatalogMenuLinkListName default value to empty.

### DIFF
--- a/src/VirtoCommerce.Xapi.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.Xapi.Core/ModuleConstants.cs
@@ -90,7 +90,7 @@ namespace VirtoCommerce.Xapi.Core
                     Name = "Frontend.CatalogMenuLinkListName",
                     ValueType = SettingValueType.ShortText,
                     GroupName = "Virto Commerce Frontend",
-                    DefaultValue = "catalog-menu",
+                    DefaultValue = string.Empty,
                     IsPublic = true
                 };
 

--- a/src/VirtoCommerce.Xapi.Web/Localizations/en.Xapi.json
+++ b/src/VirtoCommerce.Xapi.Web/Localizations/en.Xapi.json
@@ -26,7 +26,7 @@
     },
     "Frontend.CatalogMenuLinkListName": {
       "title": "Top level catalog linked list",
-      "description": "The name of the top-level Catalog Linked List. Ex: catalog-menu"
+      "description": "Specifies the name of the top-level catalog linked list (e.g., catalog-menu). If left empty, the menu will be automatically generated based on existing categories."
     },
     "Frontend.CatalogEmptyCategoriesEnabled": {
       "title": "Display empty categories",

--- a/src/VirtoCommerce.Xapi.Web/Localizations/en.Xapi.json
+++ b/src/VirtoCommerce.Xapi.Web/Localizations/en.Xapi.json
@@ -26,7 +26,7 @@
     },
     "Frontend.CatalogMenuLinkListName": {
       "title": "Top level catalog linked list",
-      "description": "The name of the top-level Catalog Linked List."
+      "description": "The name of the top-level Catalog Linked List. Ex: catalog-menu"
     },
     "Frontend.CatalogEmptyCategoriesEnabled": {
       "title": "Display empty categories",


### PR DESCRIPTION
## Description
feat: Set CatalogMenuLinkListName default value to empty.

## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/VCST-1932
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Xapi_3.811.0-pr-14-3d3a.zip