### PR TITLE
VCST-2589: bump MediatR from 9x to 12.x

### DIFF
--- a/src/VirtoCommerce.Xapi.Core/Extensions/GraphQLBuilderExtensions.cs
+++ b/src/VirtoCommerce.Xapi.Core/Extensions/GraphQLBuilderExtensions.cs
@@ -46,7 +46,7 @@ namespace VirtoCommerce.Xapi.Core.Extensions
         public static IGraphQLBuilder AddSchema(this IGraphQLBuilder builder, IServiceCollection services, Type assemblyMarker)
         {
             builder.AddGraphTypes(assemblyMarker.Assembly);
-            services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(assemblyMarker.Assembly));
+            services.AddMediatR(configuration => configuration.RegisterServicesFromAssembly(assemblyMarker.Assembly));
             services.AddAutoMapper(assemblyMarker);
             services.AddSchemaBuilders(assemblyMarker);
 
@@ -56,7 +56,7 @@ namespace VirtoCommerce.Xapi.Core.Extensions
         public static IGraphQLBuilder AddSchema(this IGraphQLBuilder builder, IServiceCollection services, Type coreAssemblyMarker, Type dataAssemblyMarker)
         {
             builder.AddGraphTypes(coreAssemblyMarker.Assembly);
-            services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblies(coreAssemblyMarker.Assembly, dataAssemblyMarker.Assembly));
+            services.AddMediatR(configuration => configuration.RegisterServicesFromAssemblies(coreAssemblyMarker.Assembly, dataAssemblyMarker.Assembly));
             services.AddAutoMapper(coreAssemblyMarker, dataAssemblyMarker);
             services.AddSchemaBuilders(dataAssemblyMarker);
 

--- a/src/VirtoCommerce.Xapi.Core/Extensions/GraphQLBuilderExtensions.cs
+++ b/src/VirtoCommerce.Xapi.Core/Extensions/GraphQLBuilderExtensions.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using GraphQL;
 using GraphQL.DI;
 using GraphQL.Validation;
-using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using ServiceLifetime = GraphQL.DI.ServiceLifetime;
 
@@ -47,7 +46,7 @@ namespace VirtoCommerce.Xapi.Core.Extensions
         public static IGraphQLBuilder AddSchema(this IGraphQLBuilder builder, IServiceCollection services, Type assemblyMarker)
         {
             builder.AddGraphTypes(assemblyMarker.Assembly);
-            services.AddMediatR(assemblyMarker);
+            services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(assemblyMarker.Assembly));
             services.AddAutoMapper(assemblyMarker);
             services.AddSchemaBuilders(assemblyMarker);
 
@@ -57,7 +56,7 @@ namespace VirtoCommerce.Xapi.Core.Extensions
         public static IGraphQLBuilder AddSchema(this IGraphQLBuilder builder, IServiceCollection services, Type coreAssemblyMarker, Type dataAssemblyMarker)
         {
             builder.AddGraphTypes(coreAssemblyMarker.Assembly);
-            services.AddMediatR(coreAssemblyMarker, dataAssemblyMarker);
+            services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblies(coreAssemblyMarker.Assembly, dataAssemblyMarker.Assembly));
             services.AddAutoMapper(coreAssemblyMarker, dataAssemblyMarker);
             services.AddSchemaBuilders(dataAssemblyMarker);
 

--- a/src/VirtoCommerce.Xapi.Core/VirtoCommerce.Xapi.Core.csproj
+++ b/src/VirtoCommerce.Xapi.Core/VirtoCommerce.Xapi.Core.csproj
@@ -20,8 +20,7 @@
     <PackageReference Include="GraphQL.Authorization" Version="8.0.0" />
     <PackageReference Include="GraphQL.Server.Transports.AspNetCore" Version="8.2.0" />
     <PackageReference Include="GraphQL.Server.Ui.GraphiQL" Version="8.2.0" />
-    <PackageReference Include="MediatR" Version="9.0.0" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
+    <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />   


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:






https://virtocommerce.atlassian.net/browse/VCST-2589
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Xapi_3.904.0-pr-24-7b52.zip