### PR TITLE
VCST-2625: Add ContinueShoppingLink setting

### DIFF
--- a/src/VirtoCommerce.Xapi.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.Xapi.Core/ModuleConstants.cs
@@ -97,6 +97,15 @@ namespace VirtoCommerce.Xapi.Core
                     IsPublic = true
                 };
 
+                public static SettingDescriptor ContinueShoppingLink { get; } = new SettingDescriptor
+                {
+                    Name = "Frontend.ContinueShoppingLink",
+                    ValueType = SettingValueType.ShortText,
+                    GroupName = "Virto Commerce Frontend",
+                    DefaultValue = string.Empty,
+                    IsPublic = true
+                };
+
                 public static IEnumerable<SettingDescriptor> AllSettings
                 {
                     get

--- a/src/VirtoCommerce.Xapi.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.Xapi.Core/ModuleConstants.cs
@@ -117,6 +117,7 @@ namespace VirtoCommerce.Xapi.Core
                         yield return SupportPhoneNumber;
                         yield return CatalogMenuLinkListName;
                         yield return CatalogEmptyCategoriesEnabled;
+                        yield return ContinueShoppingLink;
                     }
                 }
             }
@@ -131,7 +132,7 @@ namespace VirtoCommerce.Xapi.Core
                     yield return General.SupportPhoneNumber;
                     yield return General.CatalogMenuLinkListName;
                     yield return General.CatalogEmptyCategoriesEnabled;
-
+                    yield return General.ContinueShoppingLink;
                 }
             }
         }

--- a/src/VirtoCommerce.Xapi.Web/Localizations/de.Xapi.json
+++ b/src/VirtoCommerce.Xapi.Web/Localizations/de.Xapi.json
@@ -1,0 +1,36 @@
+{
+  "settings": {
+    "VirtoCommerce.Platform.EnvironmentName": {
+      "title": "Umgebungsname",
+      "description": ""
+    },
+    "Frontend.PageTitleWithStoreName": {
+      "title": "Shopname im Seitentitel anzeigen",
+      "description": "Shopname im Seitentitel anzeigen. Beispiel: 'Startseite - Shopname'."
+    },
+    "Frontend.PageTitleStoreNameAlign": {
+      "title": "Position des Shopnamens im Seitentitel",
+      "description": "Position des Shopnamens im Seitentitel. Unterstützte Werte: Anfang, Ende."
+    },
+    "Frontend.PageTitleDivider": {
+      "title": "Seitentitel-Trenner",
+      "description": "Seitentitel-Trenner. Beispiel: 'Startseite - Shopname'."
+    },
+    "Frontend.CatalogMenuLinkListName": {
+      "title": "Verknüpfte Liste des obersten Katalogs",
+      "description": "Gibt den Namen der verknüpften Liste des obersten Katalogs an (z.B. katalog-menü). Wenn leer, wird das Menü automatisch basierend auf den vorhandenen Kategorien generiert."
+    },
+    "Frontend.CatalogEmptyCategoriesEnabled": {
+      "title": "Leere Kategorien anzeigen",
+      "description": "Steuert die Anforderung zum Abrufen von Kategorien ohne Produkte"
+    },
+    "Frontend.SupportPhoneNumber": {
+      "title": "Support-Telefonnummer",
+      "description": "Die Telefonnummer im Abschnitt 'Rufen Sie uns an'"
+    },
+    "Frontend.ContinueShoppingLink": {
+      "title": "Link zum Weitershoppen",
+      "description": "Ermöglicht es Kunden, schnell zum Stöbern zurückzukehren"
+    }
+  }
+}

--- a/src/VirtoCommerce.Xapi.Web/Localizations/en.Xapi.json
+++ b/src/VirtoCommerce.Xapi.Web/Localizations/en.Xapi.json
@@ -27,6 +27,10 @@
     "Frontend.SupportPhoneNumber": {
       "title": "Support phone number",
       "description": "The phone number in the 'Call us' section"
+    },
+    "Frontend.ContinueShoppingLink": {
+      "title": "Continue shopping link",
+      "description": "Allows customers to quickly return to browsing products"
     }
   }
 }

--- a/src/VirtoCommerce.Xapi.Web/Localizations/es.Xapi.json
+++ b/src/VirtoCommerce.Xapi.Web/Localizations/es.Xapi.json
@@ -1,0 +1,36 @@
+{
+  "settings": {
+    "VirtoCommerce.Platform.EnvironmentName": {
+      "title": "Nombre del entorno",
+      "description": ""
+    },
+    "Frontend.PageTitleWithStoreName": {
+      "title": "Mostrar nombre de la tienda en el título de la página",
+      "description": "Mostrar nombre de la tienda en el título de la página. Ejemplo: 'Inicio - NombreTienda'."
+    },
+    "Frontend.PageTitleStoreNameAlign": {
+      "title": "Posición del nombre de la tienda en el título de la página",
+      "description": "Posición del nombre de la tienda en el título de la página. Valores soportados: inicio, fin."
+    },
+    "Frontend.PageTitleDivider": {
+      "title": "Divisor del título de la página",
+      "description": "Divisor del título de la página. Ejemplo: 'Inicio - NombreTienda'."
+    },
+    "Frontend.CatalogMenuLinkListName": {
+      "title": "Lista de enlaces del catálogo de nivel superior",
+      "description": "Especifica el nombre de la lista de enlaces del catálogo de nivel superior (por ejemplo, catalog-menu). Si se deja vacío, el menú se generará automáticamente en función de las categorías existentes."
+    },
+    "Frontend.CatalogEmptyCategoriesEnabled": {
+      "title": "Mostrar categorías vacías",
+      "description": "Controla la solicitud para recuperar categorías sin productos"
+    },
+    "Frontend.SupportPhoneNumber": {
+      "title": "Número de teléfono de soporte",
+      "description": "El número de teléfono en la sección 'Llámanos'"
+    },
+    "Frontend.ContinueShoppingLink": {
+      "title": "Enlace para continuar comprando",
+      "description": "Permite a los clientes volver rápidamente a navegar por los productos"
+    }
+  }
+}

--- a/src/VirtoCommerce.Xapi.Web/Localizations/fr.Xapi.json
+++ b/src/VirtoCommerce.Xapi.Web/Localizations/fr.Xapi.json
@@ -1,0 +1,36 @@
+{
+  "settings": {
+    "VirtoCommerce.Platform.EnvironmentName": {
+      "title": "Nom de l'environnement",
+      "description": ""
+    },
+    "Frontend.PageTitleWithStoreName": {
+      "title": "Afficher le nom du magasin dans le titre de la page",
+      "description": "Afficher le nom du magasin dans le titre de la page. Exemple : 'Accueil - NomDuMagasin'."
+    },
+    "Frontend.PageTitleStoreNameAlign": {
+      "title": "Position du nom du magasin dans le titre de la page",
+      "description": "Position du nom du magasin dans le titre de la page. Valeurs supportées : début, fin."
+    },
+    "Frontend.PageTitleDivider": {
+      "title": "Séparateur de titre de page",
+      "description": "Séparateur de titre de page. Exemple : 'Accueil - NomDuMagasin'."
+    },
+    "Frontend.CatalogMenuLinkListName": {
+      "title": "Liste de liens du catalogue de niveau supérieur",
+      "description": "Spécifie le nom de la liste de liens du catalogue de niveau supérieur (par exemple, menu-catalogue). Si laissé vide, le menu sera automatiquement généré en fonction des catégories existantes."
+    },
+    "Frontend.CatalogEmptyCategoriesEnabled": {
+      "title": "Afficher les catégories vides",
+      "description": "Contrôle la demande de récupération des catégories sans produits"
+    },
+    "Frontend.SupportPhoneNumber": {
+      "title": "Numéro de téléphone du support",
+      "description": "Le numéro de téléphone dans la section 'Appelez-nous'"
+    },
+    "Frontend.ContinueShoppingLink": {
+      "title": "Lien pour continuer vos achats",
+      "description": "Permet aux clients de retourner rapidement à la navigation des produits"
+    }
+  }
+}

--- a/src/VirtoCommerce.Xapi.Web/Localizations/it.Xapi.json
+++ b/src/VirtoCommerce.Xapi.Web/Localizations/it.Xapi.json
@@ -1,0 +1,36 @@
+{
+  "settings": {
+    "VirtoCommerce.Platform.EnvironmentName": {
+      "title": "Nome dell'ambiente",
+      "description": ""
+    },
+    "Frontend.PageTitleWithStoreName": {
+      "title": "Mostra il nome del negozio nel titolo della pagina",
+      "description": "Mostra il nome del negozio nel titolo della pagina. Esempio: 'Home - NomeNegozio'."
+    },
+    "Frontend.PageTitleStoreNameAlign": {
+      "title": "Posizione del nome del negozio nel titolo della pagina",
+      "description": "Posizione del nome del negozio nel titolo della pagina. Valori supportati: inizio, fine."
+    },
+    "Frontend.PageTitleDivider": {
+      "title": "Divisore del titolo della pagina",
+      "description": "Divisore del titolo della pagina. Esempio: 'Home - NomeNegozio'."
+    },
+    "Frontend.CatalogMenuLinkListName": {
+      "title": "Elenco collegato del catalogo di livello superiore",
+      "description": "Specifica il nome dell'elenco collegato del catalogo di livello superiore (ad esempio, catalog-menu). Se lasciato vuoto, il menu verrà generato automaticamente in base alle categorie esistenti."
+    },
+    "Frontend.CatalogEmptyCategoriesEnabled": {
+      "title": "Visualizza categorie vuote",
+      "description": "Controlla la richiesta per il recupero delle categorie senza prodotti"
+    },
+    "Frontend.SupportPhoneNumber": {
+      "title": "Numero di telefono di supporto",
+      "description": "Il numero di telefono nella sezione 'Chiamaci'"
+    },
+    "Frontend.ContinueShoppingLink": {
+      "title": "Link per continuare lo shopping",
+      "description": "Consente ai clienti di tornare rapidamente a navigare tra i prodotti"
+    }
+  }
+}

--- a/src/VirtoCommerce.Xapi.Web/Localizations/ja.Xapi.json
+++ b/src/VirtoCommerce.Xapi.Web/Localizations/ja.Xapi.json
@@ -1,0 +1,36 @@
+{
+  "settings": {
+    "VirtoCommerce.Platform.EnvironmentName": {
+      "title": "環境名",
+      "description": ""
+    },
+    "Frontend.PageTitleWithStoreName": {
+      "title": "ページタイトルにストア名を表示",
+      "description": "ページタイトルにストア名を表示します。例: 'ホーム - ストア名'."
+    },
+    "Frontend.PageTitleStoreNameAlign": {
+      "title": "ページタイトルのストア名の位置",
+      "description": "ページタイトルのストア名の位置。サポートされている値: 開始, 終了."
+    },
+    "Frontend.PageTitleDivider": {
+      "title": "ページタイトルの区切り文字",
+      "description": "ページタイトルの区切り文字。例: 'ホーム - ストア名'."
+    },
+    "Frontend.CatalogMenuLinkListName": {
+      "title": "トップレベルのカタログリンクリスト",
+      "description": "トップレベルのカタログリンクリストの名前を指定します（例: catalog-menu）。空のままにすると、既存のカテゴリに基づいてメニューが自動的に生成されます。"
+    },
+    "Frontend.CatalogEmptyCategoriesEnabled": {
+      "title": "空のカテゴリを表示",
+      "description": "製品のないカテゴリを取得するリクエストを制御します"
+    },
+    "Frontend.SupportPhoneNumber": {
+      "title": "サポート電話番号",
+      "description": "'お問い合わせ'セクションの電話番号"
+    },
+    "Frontend.ContinueShoppingLink": {
+      "title": "ショッピングを続けるリンク",
+      "description": "顧客が製品の閲覧にすぐに戻ることができるようにします"
+    }
+  }
+}

--- a/src/VirtoCommerce.Xapi.Web/Localizations/pl.Xapi.json
+++ b/src/VirtoCommerce.Xapi.Web/Localizations/pl.Xapi.json
@@ -1,0 +1,36 @@
+{
+  "settings": {
+    "VirtoCommerce.Platform.EnvironmentName": {
+      "title": "Nazwa środowiska",
+      "description": ""
+    },
+    "Frontend.PageTitleWithStoreName": {
+      "title": "Pokaż nazwę sklepu w tytule strony",
+      "description": "Pokaż nazwę sklepu w tytule strony. Przykład: 'Strona główna - NazwaSklepu'."
+    },
+    "Frontend.PageTitleStoreNameAlign": {
+      "title": "Pozycja nazwy sklepu w tytule strony",
+      "description": "Pozycja nazwy sklepu w tytule strony. Obsługiwane wartości: początek, koniec."
+    },
+    "Frontend.PageTitleDivider": {
+      "title": "Separator tytułu strony",
+      "description": "Separator tytułu strony. Przykład: 'Strona główna - NazwaSklepu'."
+    },
+    "Frontend.CatalogMenuLinkListName": {
+      "title": "Lista linków katalogu najwyższego poziomu",
+      "description": "Określa nazwę listy linków katalogu najwyższego poziomu (np. katalog-menu). Jeśli pozostawione puste, menu zostanie automatycznie wygenerowane na podstawie istniejących kategorii."
+    },
+    "Frontend.CatalogEmptyCategoriesEnabled": {
+      "title": "Wyświetl puste kategorie",
+      "description": "Kontroluje żądanie pobierania kategorii bez produktów"
+    },
+    "Frontend.SupportPhoneNumber": {
+      "title": "Numer telefonu wsparcia",
+      "description": "Numer telefonu w sekcji 'Zadzwoń do nas'"
+    },
+    "Frontend.ContinueShoppingLink": {
+      "title": "Link do kontynuowania zakupów",
+      "description": "Pozwala klientom szybko wrócić do przeglądania produktów"
+    }
+  }
+}

--- a/src/VirtoCommerce.Xapi.Web/Localizations/ru.Xapi.json
+++ b/src/VirtoCommerce.Xapi.Web/Localizations/ru.Xapi.json
@@ -1,0 +1,36 @@
+{
+  "settings": {
+    "VirtoCommerce.Platform.EnvironmentName": {
+      "title": "Имя окружения",
+      "description": ""
+    },
+    "Frontend.PageTitleWithStoreName": {
+      "title": "Показывать имя магазина в заголовке страницы",
+      "description": "Показывать имя магазина в заголовке страницы. Пример: 'Главная - Имя Магазина'."
+    },
+    "Frontend.PageTitleStoreNameAlign": {
+      "title": "Позиция имени магазина в заголовке страницы",
+      "description": "Позиция имени магазина в заголовке страницы. Поддерживаемые значения: начало, конец."
+    },
+    "Frontend.PageTitleDivider": {
+      "title": "Разделитель заголовка страницы",
+      "description": "Разделитель заголовка страницы. Пример: 'Главная - Имя Магазина'."
+    },
+    "Frontend.CatalogMenuLinkListName": {
+      "title": "Список ссылок верхнего уровня каталога",
+      "description": "Указывает имя списка ссылок верхнего уровня каталога (например, catalog-menu). Если оставить пустым, меню будет автоматически сгенерировано на основе существующих категорий."
+    },
+    "Frontend.CatalogEmptyCategoriesEnabled": {
+      "title": "Отображать пустые категории",
+      "description": "Управляет запросом на получение категорий без продуктов"
+    },
+    "Frontend.SupportPhoneNumber": {
+      "title": "Номер телефона поддержки",
+      "description": "Номер телефона в разделе 'Позвоните нам'"
+    },
+    "Frontend.ContinueShoppingLink": {
+      "title": "Ссылка для продолжения покупок",
+      "description": "Позволяет клиентам быстро вернуться к просмотру товаров"
+    }
+  }
+}

--- a/src/VirtoCommerce.Xapi.Web/Localizations/zh.Xapi.json
+++ b/src/VirtoCommerce.Xapi.Web/Localizations/zh.Xapi.json
@@ -1,0 +1,36 @@
+{
+  "settings": {
+    "VirtoCommerce.Platform.EnvironmentName": {
+      "title": "环境名称",
+      "description": ""
+    },
+    "Frontend.PageTitleWithStoreName": {
+      "title": "在页面标题中显示商店名称",
+      "description": "在页面标题中显示商店名称。例如：'首页 - 商店名称'。"
+    },
+    "Frontend.PageTitleStoreNameAlign": {
+      "title": "页面标题中商店名称的位置",
+      "description": "页面标题中商店名称的位置。支持的值：开始，结束。"
+    },
+    "Frontend.PageTitleDivider": {
+      "title": "页面标题分隔符",
+      "description": "页面标题分隔符。例如：'首页 - 商店名称'。"
+    },
+    "Frontend.CatalogMenuLinkListName": {
+      "title": "顶级目录链接列表",
+      "description": "指定顶级目录链接列表的名称（例如，catalog-menu）。如果留空，菜单将根据现有类别自动生成。"
+    },
+    "Frontend.CatalogEmptyCategoriesEnabled": {
+      "title": "显示空类别",
+      "description": "它控制请求以检索没有产品的类别"
+    },
+    "Frontend.SupportPhoneNumber": {
+      "title": "支持电话号码",
+      "description": "'联系我们'部分的电话号码"
+    },
+    "Frontend.ContinueShoppingLink": {
+      "title": "继续购物链接",
+      "description": "允许客户快速返回浏览产品"
+    }
+  }
+}


### PR DESCRIPTION
## Description
feat: Add ContinueShoppingLink setting that allows customers to quickly return to browsing products and update localizations

## References
### QA-test:
### Jira-link:


https://virtocommerce.atlassian.net/browse/VCST-2625
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Xapi_3.905.0-pr-27-830a.zip