### PR TITLE
VCST-3138: More efficient way to select best SEO item

### DIFF
--- a/src/VirtoCommerce.Xapi.Core/VirtoCommerce.Xapi.Core.csproj
+++ b/src/VirtoCommerce.Xapi.Core/VirtoCommerce.Xapi.Core.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.811.0" />
     <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.817.0" />
     <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.804.0" />
-    <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.813.0" />
+    <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.814.0" />
     <PackageReference Include="VirtoCommerce.TaxModule.Core" Version="3.802.0" />
   </ItemGroup>
 

--- a/src/VirtoCommerce.Xapi.Data/Queries/SlugInfoQueryHandler.cs
+++ b/src/VirtoCommerce.Xapi.Data/Queries/SlugInfoQueryHandler.cs
@@ -59,9 +59,7 @@ namespace VirtoCommerce.Xapi.Data.Queries
         protected virtual async Task<SeoInfo> GetBestMatchingSeoInfo(SeoSearchCriteria criteria, Store store)
         {
             var itemsToMatch = await _seoResolver.FindSeoAsync(criteria);
-            // result should have items only from current store or without store
-            var result = itemsToMatch.Where(x => x.StoreId == store.Id || string.IsNullOrEmpty(x.StoreId));
-            return result.GetBestMatchingSeoInfo(store, criteria.LanguageCode, criteria.Slug, criteria.Permalink);
+            return itemsToMatch.GetBestMatchingSeoInfo(store, criteria.LanguageCode, criteria.Slug, criteria.Permalink);
         }
     }
 }

--- a/src/VirtoCommerce.Xapi.Data/Queries/SlugInfoQueryHandler.cs
+++ b/src/VirtoCommerce.Xapi.Data/Queries/SlugInfoQueryHandler.cs
@@ -59,17 +59,9 @@ namespace VirtoCommerce.Xapi.Data.Queries
         protected virtual async Task<SeoInfo> GetBestMatchingSeoInfo(SeoSearchCriteria criteria, Store store)
         {
             var itemsToMatch = await _seoResolver.FindSeoAsync(criteria);
-
-            var seoInfosForStore = itemsToMatch.Where(x => x.StoreId == store.Id).ToArray();
-            var bestMatchSeoInfo = seoInfosForStore.GetBestMatchingSeoInfo(store, criteria.LanguageCode, criteria.Slug, criteria.Permalink);
-
-            if (bestMatchSeoInfo == null)
-            {
-                var seoInfosWithoutStore = itemsToMatch.Where(x => string.IsNullOrEmpty(x.StoreId)).ToArray();
-                bestMatchSeoInfo = seoInfosWithoutStore.GetBestMatchingSeoInfo(store, criteria.LanguageCode, criteria.Slug, criteria.Permalink);
-            }
-
-            return bestMatchSeoInfo;
+            // result should have items only from current store or without store
+            var result = itemsToMatch.Where(x => x.StoreId == store.Id || string.IsNullOrEmpty(x.StoreId));
+            return result.GetBestMatchingSeoInfo(store, criteria.LanguageCode, criteria.Slug, criteria.Permalink);
         }
     }
 }

--- a/src/VirtoCommerce.Xapi.Web/module.manifest
+++ b/src/VirtoCommerce.Xapi.Web/module.manifest
@@ -10,7 +10,7 @@
     <dependency id="VirtoCommerce.Core" version="3.811.0" />
     <dependency id="VirtoCommerce.Customer" version="3.817.0" />
     <dependency id="VirtoCommerce.Search" version="3.804.0" />
-    <dependency id="VirtoCommerce.Store" version="3.813.0" />
+    <dependency id="VirtoCommerce.Store" version="3.814.0" />
     <dependency id="VirtoCommerce.Tax" version="3.802.0" optional="true" />
   </dependencies>
   <incompatibilities>


### PR DESCRIPTION
## Description

The helper function was changed to calculate correct score when choosing the most approched item. So, You don't need to filter items by store and call it twice.

## References
### QA-test:
### Jira-link:


https://virtocommerce.atlassian.net/browse/VCST-3138
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Xapi_3.914.0-pr-40-31a5.zip