### PR TITLE
VCST-4721: Extend CurrencyType with Name

### DIFF
--- a/src/VirtoCommerce.Xapi.Core/Schemas/CurrencyType.cs
+++ b/src/VirtoCommerce.Xapi.Core/Schemas/CurrencyType.cs
@@ -6,12 +6,13 @@ namespace VirtoCommerce.Xapi.Core.Schemas
     {
         public CurrencyType()
         {
+            Field(x => x.Name, nullable: false).Description("Currency name");
             Field(x => x.Code, nullable: false).Description("Currency code may be used ISO 4217");
             Field(x => x.Symbol, nullable: false).Description("Symbol");
             Field(x => x.ExchangeRate, nullable: false).Description("Exchange rate");
             Field(x => x.CustomFormatting, nullable: true).Description("Currency custom formatting");
-            Field(x => x.EnglishName, nullable: false).Description("Currency English name");
-            Field(x => x.CultureName, nullable: false).Description("Currency English name");
+            Field(x => x.EnglishName, nullable: false).Description("Currency english name");
+            Field(x => x.CultureName, nullable: false).Description("Currency culture name");
         }
     }
 }


### PR DESCRIPTION
## Description
feat: Extends CurrencyType with Name property.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4721
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Xapi_3.1005.0-pr-67-fe38.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new non-null `name` field to the GraphQL `CurrencyType`, which is mostly additive but could cause runtime GraphQL errors if any currency records have a null `Name`. Remaining changes are description text updates only.
> 
> **Overview**
> Exposes currency `Name` via the GraphQL `CurrencyType` by adding a new non-null `name` field.
> 
> Also updates the field descriptions for `EnglishName` and `CultureName` to be more accurate.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe38c83f293cbb7f671dd871283bb8ae3721cae5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->