### PR TITLE
VCST-4686: Don't take user name from headers

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,4 +9,7 @@
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
+  <ItemGroup>
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-rvv3-g6hj-g44x" />
+  </ItemGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
+    <!--Ignore the irrelevant AutoMapper vulnerability-->
     <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-rvv3-g6hj-g44x" />
   </ItemGroup>
 </Project>

--- a/VirtoCommerce.Xapi.sln.DotSettings
+++ b/VirtoCommerce.Xapi.sln.DotSettings
@@ -1,9 +1,10 @@
 <wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=QL/@EntryIndexedValue">QL</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/UserRules/=15b5b1f1_002D457c_002D4ca6_002Db278_002D5615aedc07d3/@EntryIndexedValue">&lt;Policy&gt;&lt;Descriptor Staticness="Static" AccessRightKinds="Private" Description="Static readonly fields (private)"&gt;&lt;ElementKinds&gt;&lt;Kind Name="READONLY_FIELD" /&gt;&lt;/ElementKinds&gt;&lt;/Descriptor&gt;&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="aaBb" /&gt;&lt;/Policy&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/UserRules/=236f7aa5_002D7b06_002D43ca_002Dbf2a_002D9b31bfcff09a/@EntryIndexedValue">&lt;Policy&gt;&lt;Descriptor Staticness="Any" AccessRightKinds="Private" Description="Constant fields (private)"&gt;&lt;ElementKinds&gt;&lt;Kind Name="CONSTANT_FIELD" /&gt;&lt;/ElementKinds&gt;&lt;/Descriptor&gt;&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="aaBb" /&gt;&lt;/Policy&gt;</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=executer/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=openIddict/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=pricelist/@EntryIndexedValue">True</s:Boolean>
-  <s:Boolean x:Key="/Default/UserDictionary/Words/=virto/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=virto/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=xapi/@EntryIndexedValue">True</s:Boolean>
 </wpf:ResourceDictionary>

--- a/src/VirtoCommerce.Xapi.Core/Extensions/GraphQLUserContextExtensions.cs
+++ b/src/VirtoCommerce.Xapi.Core/Extensions/GraphQLUserContextExtensions.cs
@@ -1,0 +1,31 @@
+using VirtoCommerce.Xapi.Core.Infrastructure;
+
+namespace VirtoCommerce.Xapi.Core.Extensions;
+
+public static class GraphQLUserContextExtensions
+{
+    public const string OperatorUserNameKey = "OperatorUserName";
+
+    public static bool TrySetOperatorUserName(this GraphQLUserContext userContext, string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return false;
+        }
+
+        return userContext.TryAdd(OperatorUserNameKey, value);
+    }
+
+    public static bool TryGetOperatorUserName(this GraphQLUserContext userContext, out string value)
+    {
+        if (!userContext.TryGetValue(OperatorUserNameKey, out var objectValue))
+        {
+            value = null;
+            return false;
+        }
+
+        value = objectValue as string;
+
+        return !string.IsNullOrEmpty(value);
+    }
+}

--- a/src/VirtoCommerce.Xapi.Core/VirtoCommerce.Xapi.Core.csproj
+++ b/src/VirtoCommerce.Xapi.Core/VirtoCommerce.Xapi.Core.csproj
@@ -11,7 +11,8 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="12.0.1" />
+    <!--Don't update. AutoMapper 15+ requires a paid license for commercial use.-->
+    <PackageReference Include="AutoMapper" Version="[12.0.1,15)" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="GraphQL" Version="8.8.3" />
     <PackageReference Include="GraphQL.DataLoader" Version="8.8.3" />

--- a/src/VirtoCommerce.Xapi.Web/Extensions/HttpContextExtensions.cs
+++ b/src/VirtoCommerce.Xapi.Web/Extensions/HttpContextExtensions.cs
@@ -1,93 +1,22 @@
-using System;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Identity;
-using Microsoft.Extensions.DependencyInjection;
-using OpenIddict.Abstractions;
 using VirtoCommerce.Platform.Core;
-using VirtoCommerce.Platform.Core.Security;
+using VirtoCommerce.Xapi.Core.Extensions;
 using VirtoCommerce.Xapi.Core.Infrastructure;
 
 namespace VirtoCommerce.Xapi.Web.Extensions
 {
     public static class HttpContextExtensions
     {
-        public static async Task<GraphQLUserContext> BuildGraphQLUserContextAsync(this HttpContext context)
+        public static Task<GraphQLUserContext> BuildGraphQLUserContextAsync(this HttpContext context)
         {
-            var loginOnBehalfContext = new LoginOnBehalfContext
-            {
-                Principal = context.User,
-                OperatorUserName = default
-            };
+            var userContext = new GraphQLUserContext(context.User);
 
-            // Impersonate a user based on their VC account object id by passing that value along with the header VirtoCommerce-User-Name.
-            if (loginOnBehalfContext.Principal != null &&
-                !TryResolveTokenLoginOnBehalf(loginOnBehalfContext))
-            {
-                await TryResolveLegacyLoginOnBehalfAsync(context, loginOnBehalfContext);
-            }
+            var operatorUserName = context.User.FindFirstValue(PlatformConstants.Security.Claims.OperatorUserName);
+            userContext.TrySetOperatorUserName(operatorUserName);
 
-            var userContext = new GraphQLUserContext(loginOnBehalfContext.Principal);
-
-            if (!string.IsNullOrEmpty(loginOnBehalfContext.OperatorUserName))
-            {
-                userContext.TryAdd("OperatorUserName", loginOnBehalfContext.OperatorUserName);
-            }
-
-            return userContext;
-        }
-
-        private static bool TryResolveTokenLoginOnBehalf(LoginOnBehalfContext loginOnBehalfContext)
-        {
-            loginOnBehalfContext.OperatorUserName = loginOnBehalfContext.Principal.FindFirstValue(PlatformConstants.Security.Claims.OperatorUserName);
-
-            return !string.IsNullOrEmpty(loginOnBehalfContext.OperatorUserName);
-        }
-
-        private static async Task<bool> TryResolveLegacyLoginOnBehalfAsync(HttpContext context, LoginOnBehalfContext loginOnBehalfContext)
-        {
-            if (!context.Request.Headers.TryGetValue("VirtoCommerce-User-Name", out var userNameFromHeader) ||
-                !loginOnBehalfContext.Principal.IsInRole(PlatformConstants.Security.SystemRoles.Administrator))
-            {
-                return false;
-            }
-
-            if (userNameFromHeader == "Anonymous")
-            {
-                var identity = new ClaimsIdentity();
-
-                if (context.Request.Headers.TryGetValue("VirtoCommerce-Anonymous-User-Id", out var anonymousUserId))
-                {
-                    identity.AddClaim(ClaimTypes.NameIdentifier, anonymousUserId);
-                }
-
-                loginOnBehalfContext.Principal = new ClaimsPrincipal(identity);
-            }
-            else
-            {
-                var factory = context.RequestServices.GetService<Func<SignInManager<ApplicationUser>>>();
-                var signInManager = factory();
-                var user = await signInManager.UserManager.FindByNameAsync(userNameFromHeader);
-                if (user != null)
-                {
-                    loginOnBehalfContext.Principal = await signInManager.CreateUserPrincipalAsync(user);
-                }
-
-                // try to find LoginOnBehalf operator, if VirtoCommerce-Operator-User-Name header is present
-                if (context.Request.Headers.TryGetValue("VirtoCommerce-Operator-User-Name", out var operatorUserNameHeader))
-                {
-                    loginOnBehalfContext.OperatorUserName = operatorUserNameHeader;
-                }
-            }
-
-            return true;
-        }
-
-        private sealed class LoginOnBehalfContext
-        {
-            public ClaimsPrincipal Principal { get; set; }
-            public string OperatorUserName { get; set; }
+            return Task.FromResult(userContext);
         }
     }
 }


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4686
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Xapi_3.1006.0-pr-68-795d.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how request identity/impersonation is derived for GraphQL by removing header-based login-on-behalf resolution, which could affect admin workflows that relied on those headers. Package/audit tweaks are low risk but the auth-context behavioral change warrants careful verification.
> 
> **Overview**
> **GraphQL user context construction no longer trusts request headers for impersonation.** `BuildGraphQLUserContextAsync` is simplified to always use `HttpContext.User` and to set `OperatorUserName` only from the `PlatformConstants.Security.Claims.OperatorUserName` claim, deleting the prior legacy flow that read `VirtoCommerce-User-Name`/`VirtoCommerce-Operator-User-Name` (and could create principals for other users).
> 
> Adds `GraphQLUserContext` helpers (`TrySetOperatorUserName`/`TryGetOperatorUserName`) to centralize the `OperatorUserName` key, and updates build settings to suppress a specific AutoMapper audit advisory while constraining `AutoMapper` to `[12.0.1,15)` to avoid the paid-license major versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 795d34f80dc74641170af163ac178f5a79a49887. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->