### PR TITLE
VCST-5275: Make GetStoreQueryHandler.Handle virtual for extensibility

### DIFF
--- a/src/VirtoCommerce.Xapi.Data/Queries/GetStoreQueryHandler.cs
+++ b/src/VirtoCommerce.Xapi.Data/Queries/GetStoreQueryHandler.cs
@@ -64,7 +64,7 @@ public class GetStoreQueryHandler : IQueryHandler<GetStoreQuery, StoreResponse>
         _moduleService = moduleService;
     }
 
-    public async Task<StoreResponse> Handle(GetStoreQuery request, CancellationToken cancellationToken)
+    public virtual async Task<StoreResponse> Handle(GetStoreQuery request, CancellationToken cancellationToken)
     {
         var storeResolverRequest = CreateStoreResolveRequest(request);
         var store = await _storeDomainResolverService.GetStoreAsync(storeResolverRequest);


### PR DESCRIPTION
## VCST-5275 — Make `GetStoreQueryHandler.Handle` virtual

**DO NOT MERGE until human review.**

Extensibility request from Innovadis (Support #39304): allow consumers to override the GetStore query handler. The `Handle` method on `GetStoreQueryHandler` was the only non-virtual public member; this adds the `virtual` keyword so it can be overridden.

JIRA: https://virtocommerce.atlassian.net/browse/VCST-5275

### Change (entire diff — one keyword)
```diff
-    public async Task<StoreResponse> Handle(GetStoreQuery request, CancellationToken cancellationToken)
+    public virtual async Task<StoreResponse> Handle(GetStoreQuery request, CancellationToken cancellationToken)
```
`src/VirtoCommerce.Xapi.Data/Queries/GetStoreQueryHandler.cs` — 1 file changed, 1 insertion(+), 1 deletion(-).

### Why this is safe (non-breaking)
- Adding `virtual` to a method on a **non-sealed** `public class` is binary- and source-compatible — existing callers and subclasses keep compiling/running unchanged; it only *widens* the contract by permitting `override`.
- No public REST/GraphQL/DTO/contract surface, manifest, DB schema/migration, or domain-event shape is affected. The `store` GraphQL resolution path is behaviorally identical.
- Consistency: the sibling helpers (`CreateStoreResolveRequest`, `ResolveStoreByDomain`, `ToModulesSettings`, `GetModuleVersion`, `ToSettingValue`) are already `protected virtual`; this aligns `Handle` with the class's established extensibility pattern.

### Verification
- **Reproduction:** trivial-skip (one-keyword change, no behavioral branch; `GetStoreQueryHandler` has an 11-dependency constructor, so a derive-and-override test would be disproportionately heavy for zero behavioral coverage gain).
- **Local build:** `dotnet build src/VirtoCommerce.Xapi.Data` — succeeded, 0 warnings (`TreatWarningsAsErrors=true`).
- **Local tests:** `dotnet test tests/VirtoCommerce.Xapi.Tests` — 175 passed, 0 failed, 1 pre-existing skip. No existing tests modified.

### Notes for the reviewer
- This is an **extensibility request, not a defect** — the `feat(xapi)` commit type reflects that. (`/qa-fix` Gate 0 non-bug scope was a user-approved override.)
- **needs deploy verification** — statically/unit-proven only; CI (build + unit + Swagger validation + SonarCloud QG + auto-tests) is the authoritative gate.
- Customer requested this on **3.1003.0** — backport is a separate human decision, out of scope for this PR (targets `dev`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Xapi_3.1011.0-pr-73-f9af.zip