### PR TITLE
Boolean GraphQL types support

### DIFF
--- a/src/VirtoCommerce.Xapi.Core/Infrastructure/SchemaFactory.cs
+++ b/src/VirtoCommerce.Xapi.Core/Infrastructure/SchemaFactory.cs
@@ -78,11 +78,20 @@ namespace VirtoCommerce.Xapi.Core.Infrastructure
             schema.RegisterTypeMapping<Optional<decimal?>, OptionalNullableDecimalGraphType>();
             schema.RegisterTypeMapping<Optional<int>, OptionalIntGraphType>();
             schema.RegisterTypeMapping<Optional<int?>, OptionalNullableIntGraphType>();
+            schema.RegisterTypeMapping<Optional<bool>, OptionalBooleanGraphType>();
+            schema.RegisterTypeMapping<Optional<bool?>, OptionalNullableBooleanGraphType>();
 
             // Map common value conversions to Optional
             ValueConverter.Register<int, Optional<int>>(x => new Optional<int>(x));
+            ValueConverter.Register<int, Optional<int?>>(x => new Optional<int?>(x));
+            ValueConverter.Register<int?, Optional<int?>>(x => new Optional<int?>(x));
             ValueConverter.Register<decimal, Optional<decimal>>(x => new Optional<decimal>(x));
+            ValueConverter.Register<decimal, Optional<decimal?>>(x => new Optional<decimal?>(x));
+            ValueConverter.Register<decimal?, Optional<decimal?>>(x => new Optional<decimal?>(x));
             ValueConverter.Register<string, Optional<string>>(x => new Optional<string>(x));
+            ValueConverter.Register<bool, Optional<bool>>(x => new Optional<bool>(x));
+            ValueConverter.Register<bool, Optional<bool?>>(x => new Optional<bool?>(x));
+            ValueConverter.Register<bool?, Optional<bool?>>(x => new Optional<bool?>(x));
 
             // Clean Query, Mutation and Subscription if they have no fields
             // to prevent GraphQL configuration errors.

--- a/src/VirtoCommerce.Xapi.Core/Schemas/ScalarTypes/OptionalBooleanGraphType.cs
+++ b/src/VirtoCommerce.Xapi.Core/Schemas/ScalarTypes/OptionalBooleanGraphType.cs
@@ -1,0 +1,22 @@
+using GraphQL.Types;
+using VirtoCommerce.Xapi.Core.Infrastructure;
+
+namespace VirtoCommerce.Xapi.Core.Schemas.ScalarTypes
+{
+    public sealed class OptionalBooleanGraphType : BooleanGraphType
+    {
+        public OptionalBooleanGraphType()
+        {
+            Name = "OptionalBoolean";
+        }
+
+        public override object ParseValue(object value)
+        {
+            var parsedValue = base.ParseValue(value);
+
+            var result = new Optional<bool>(parsedValue);
+
+            return result;
+        }
+    }
+}

--- a/src/VirtoCommerce.Xapi.Core/Schemas/ScalarTypes/OptionalNullableBooleanGraphType.cs
+++ b/src/VirtoCommerce.Xapi.Core/Schemas/ScalarTypes/OptionalNullableBooleanGraphType.cs
@@ -1,0 +1,22 @@
+using GraphQL.Types;
+using VirtoCommerce.Xapi.Core.Infrastructure;
+
+namespace VirtoCommerce.Xapi.Core.Schemas.ScalarTypes
+{
+    public sealed class OptionalNullableBooleanGraphType : BooleanGraphType
+    {
+        public OptionalNullableBooleanGraphType()
+        {
+            Name = "OptionalNullableBoolean";
+        }
+
+        public override object ParseValue(object value)
+        {
+            var parsedValue = base.ParseValue(value);
+
+            var result = new Optional<bool?>(parsedValue);
+
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
## Description

Adds first-class support for boolean fields wrapped in Optional<T>, closing a gap in xAPI's partial-update story. The Optional<T> pattern lets mutation inputs distinguish "field not supplied" from "field explicitly set" — previously available for int, decimal, and string, but not bool. Without this, boolean flags in mutation inputs couldn't participate in the same conditional-mapping logic (if (input.Field.IsSpecified) ...) as other scalars.

This PR:

* Adds two scalar graph types — OptionalBooleanGraphType (OptionalBoolean) and OptionalNullableBooleanGraphType (OptionalNullableBoolean) — mirroring the existing int/decimal implementations.
* Registers the type mappings Optional<bool> → OptionalBooleanGraphType and Optional<bool?> → OptionalNullableBooleanGraphType in SchemaFactory.
* Registers ValueConverter entries for bool → Optional<bool>, bool → Optional<bool?>, and bool? → Optional<bool?>.
Additionally backfills previously missing converters for the numeric nullable variants: int → Optional<int?>, int? → Optional<int?>, decimal → Optional<decimal?>, and decimal? → Optional<decimal?>.

## References
### QA-test:
### Jira-link:
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Xapi_3.1013.0-pr-74-4c19.zip