### PR TITLE
VCST-5163: Stable 15 — Xapi (platform 3.1039.0)

### DIFF
--- a/src/VirtoCommerce.Xapi.Core/Extensions/IHasLanguageExtensions.cs
+++ b/src/VirtoCommerce.Xapi.Core/Extensions/IHasLanguageExtensions.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using VirtoCommerce.Platform.Core.Common;
-using VirtoCommerce.Platform.Core.Domain;
 
 namespace VirtoCommerce.Xapi.Core.Extensions
 {
@@ -41,18 +40,6 @@ namespace VirtoCommerce.Xapi.Core.Extensions
                 result = hasLanguagesCollection.FirstOrDefault(x => langSelector(x) == null);
             }
             return result;
-        }
-
-        /// <summary>
-        /// Looking for first best-match language-specific value in the enumerable
-        /// </summary>
-        /// <param name="hasLanguages">An enumerable with values to search</param>
-        /// <param name="language">Language to search</param>
-        /// <returns>First matching item to the specified language</returns>
-        [Obsolete("Use IEnumerable<IHasLanguageCode>.FirstBestMatchForLanguage()", DiagnosticId = "VC0011", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
-        public static IHasLanguage FirstBestMatchForLanguage(this IEnumerable<IHasLanguage> hasLanguages, string language)
-        {
-            return hasLanguages.FirstBestMatchForLanguage(x => x.LanguageCode, language);
         }
     }
 }

--- a/src/VirtoCommerce.Xapi.Core/VirtoCommerce.Xapi.Core.csproj
+++ b/src/VirtoCommerce.Xapi.Core/VirtoCommerce.Xapi.Core.csproj
@@ -28,11 +28,11 @@
     <PackageReference Include="PipelineNet" Version="0.9.0" />
     <PackageReference Include="RedLock.net" Version="2.3.2" />
     <PackageReference Include="System.Reactive" Version="6.1.0" />
-    <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Seo.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.TaxModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1010.0" />
+    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.1004.0" />
+    <PackageReference Include="VirtoCommerce.Seo.Core" Version="3.1004.0" />
+    <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1005.0" />
+    <PackageReference Include="VirtoCommerce.TaxModule.Core" Version="3.1003.0" />
   </ItemGroup>
 
 </Project>

--- a/src/VirtoCommerce.Xapi.Data/VirtoCommerce.Xapi.Data.csproj
+++ b/src/VirtoCommerce.Xapi.Data/VirtoCommerce.Xapi.Data.csproj
@@ -9,7 +9,7 @@
       <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1027.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.Xapi.Core\VirtoCommerce.Xapi.Core.csproj" />

--- a/src/VirtoCommerce.Xapi.Web/module.manifest
+++ b/src/VirtoCommerce.Xapi.Web/module.manifest
@@ -4,14 +4,14 @@
   <version>3.1011.0</version>
   <version-tag></version-tag>
 
-  <platformVersion>3.1027.0</platformVersion>
+  <platformVersion>3.1039.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.ApplicationInsights" version="3.1001.0" optional="true" />
-    <dependency id="VirtoCommerce.Customer" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Search" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Seo" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Store" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Tax" version="3.1000.0" optional="true" />
+    <dependency id="VirtoCommerce.ApplicationInsights" version="3.1004.0" optional="true" />
+    <dependency id="VirtoCommerce.Customer" version="3.1010.0" />
+    <dependency id="VirtoCommerce.Search" version="3.1004.0" />
+    <dependency id="VirtoCommerce.Seo" version="3.1004.0" />
+    <dependency id="VirtoCommerce.Store" version="3.1005.0" />
+    <dependency id="VirtoCommerce.Tax" version="3.1003.0" optional="true" />
   </dependencies>
   <incompatibilities>
     <module id="VirtoCommerce.ExperienceApi" version="3.800.0" />

--- a/tests/VirtoCommerce.Xapi.Tests/VirtoCommerce.Xapi.Tests.csproj
+++ b/tests/VirtoCommerce.Xapi.Tests/VirtoCommerce.Xapi.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Part of **Stable 15** (Wave 5). Builds against published platform [3.1039.0](https://github.com/VirtoCommerce/vc-platform/releases/tag/3.1039.0) + Wave 1–4 packages on nuget.org. Version handled by CI.

- Removed obsolete IHasLanguage extension (used removed platform IHasLanguage); 16 cascading obsoletes deferred.
- `vc-build Compress` green incl. unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Platform and cross-module version bumps can surface breaking API changes at runtime; the removed extension is a compile-time break for any external caller still using `IEnumerable<IHasLanguage>`.
> 
> **Overview**
> Aligns **VirtoCommerce.Xapi** with **Stable 15** by targeting platform **3.1039.0** and bumping related NuGet and `module.manifest` dependency versions (Customer, Search, Seo, Store, Tax, ApplicationInsights, Platform.Security).
> 
> Removes the obsolete `IHasLanguage` overload of `FirstBestMatchForLanguage` and the `VirtoCommerce.Platform.Core.Domain` import, leaving the `IHasLanguageCode` and generic selector APIs that the module already uses (e.g. facet label mapping).
> 
> Tests pick up **coverlet.collector** **10.0.1** only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7019f14e2eae4914c8aafc0088bcfb3163c1fbc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5163
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Xapi_3.1012.0-pr-75-7019.zip