### PR TITLE
VCST-5159: Frontend plugins

### DIFF
--- a/src/VirtoCommerce.Xapi.Core/Models/StorePlugin.cs
+++ b/src/VirtoCommerce.Xapi.Core/Models/StorePlugin.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using System.Linq;
+using VirtoCommerce.Platform.Core.Modularity;
+
+namespace VirtoCommerce.Xapi.Core.Models;
+
+/// <summary>
+/// A frontend (Module Federation) plugin delivered by an installed module and
+/// discovered by the platform for a given host app (e.g. <c>vc-frontend</c>).
+/// XAPI-owned projection of the platform's <c>PluginDescriptor</c>.
+/// </summary>
+public class StorePlugin
+{
+    public string Id { get; set; }
+
+    public string Version { get; set; }
+
+    /// <summary>Permission the consuming SPA evaluates before loading the plugin. Null when unrestricted.</summary>
+    public string Permission { get; set; }
+
+    /// <summary>The plugin's entry asset (its <c>remoteEntry.js</c>).</summary>
+    public StorePluginFile Entry { get; set; }
+
+    /// <summary>Additional assets (extra scripts/styles) the plugin ships.</summary>
+    public IList<StorePluginFile> ContentFiles { get; set; } = new List<StorePluginFile>();
+
+    /// <summary>Module Federation remote coordinates.</summary>
+    public StorePluginRemote Remote { get; set; }
+
+    /// <summary>
+    /// Maps a platform <see cref="PluginDescriptor"/> to its XAPI projection.
+    /// Pure and null-tolerant so it can be unit-tested without a running schema.
+    /// </summary>
+    public static StorePlugin FromDescriptor(PluginDescriptor descriptor)
+    {
+        if (descriptor == null)
+        {
+            return null;
+        }
+
+        return new StorePlugin
+        {
+            Id = descriptor.Id,
+            Version = descriptor.Version,
+            Permission = descriptor.Permission,
+            Entry = FromFileDescriptor(descriptor.Entry),
+            ContentFiles = descriptor.ContentFiles?.Select(FromFileDescriptor).ToList() ?? [],
+            Remote = descriptor.Remote == null
+                ? null
+                : new StorePluginRemote
+                {
+                    Name = descriptor.Remote.Name,
+                    Exposed = descriptor.Remote.Exposed,
+                },
+        };
+    }
+
+    private static StorePluginFile FromFileDescriptor(ContentFileDescriptor file)
+    {
+        return file == null
+            ? null
+            : new StorePluginFile
+            {
+                Type = file.Type,
+                Path = file.Path,
+                Hash = file.Hash,
+            };
+    }
+}

--- a/src/VirtoCommerce.Xapi.Core/Models/StorePluginFile.cs
+++ b/src/VirtoCommerce.Xapi.Core/Models/StorePluginFile.cs
@@ -1,0 +1,17 @@
+namespace VirtoCommerce.Xapi.Core.Models;
+
+/// <summary>
+/// A single asset (script or style) that belongs to a frontend plugin.
+/// Mirrors the platform's <c>ContentFileDescriptor</c>.
+/// </summary>
+public class StorePluginFile
+{
+    /// <summary>Asset kind, e.g. <c>script</c> or <c>style</c>.</summary>
+    public string Type { get; set; }
+
+    /// <summary>Public URL of the asset, e.g. <c>/modules/$(ModuleId)/plugins/vc-frontend/remoteEntry.js</c>.</summary>
+    public string Path { get; set; }
+
+    /// <summary>Cache-busting hash derived from the file's last-write time.</summary>
+    public string Hash { get; set; }
+}

--- a/src/VirtoCommerce.Xapi.Core/Models/StorePluginRemote.cs
+++ b/src/VirtoCommerce.Xapi.Core/Models/StorePluginRemote.cs
@@ -1,0 +1,14 @@
+namespace VirtoCommerce.Xapi.Core.Models;
+
+/// <summary>
+/// Module Federation remote coordinates for a frontend plugin.
+/// Mirrors the platform's <c>PluginRemoteDescriptor</c>.
+/// </summary>
+public class StorePluginRemote
+{
+    /// <summary>Federation remote name.</summary>
+    public string Name { get; set; }
+
+    /// <summary>Exposed module path, e.g. <c>./Module</c>.</summary>
+    public string Exposed { get; set; }
+}

--- a/src/VirtoCommerce.Xapi.Core/Schemas/StorePluginFileType.cs
+++ b/src/VirtoCommerce.Xapi.Core/Schemas/StorePluginFileType.cs
@@ -1,0 +1,13 @@
+using VirtoCommerce.Xapi.Core.Models;
+
+namespace VirtoCommerce.Xapi.Core.Schemas;
+
+public class StorePluginFileType : ExtendableGraphType<StorePluginFile>
+{
+    public StorePluginFileType()
+    {
+        Field(x => x.Type, nullable: true).Description("Asset kind, e.g. 'script' or 'style'");
+        Field(x => x.Path, nullable: true).Description("Public URL of the asset");
+        Field(x => x.Hash, nullable: true).Description("Cache-busting hash derived from the file's last-write time");
+    }
+}

--- a/src/VirtoCommerce.Xapi.Core/Schemas/StorePluginRemoteType.cs
+++ b/src/VirtoCommerce.Xapi.Core/Schemas/StorePluginRemoteType.cs
@@ -1,0 +1,12 @@
+using VirtoCommerce.Xapi.Core.Models;
+
+namespace VirtoCommerce.Xapi.Core.Schemas;
+
+public class StorePluginRemoteType : ExtendableGraphType<StorePluginRemote>
+{
+    public StorePluginRemoteType()
+    {
+        Field(x => x.Name, nullable: true).Description("Module Federation remote name");
+        Field(x => x.Exposed, nullable: true).Description("Exposed module path, e.g. './Module'");
+    }
+}

--- a/src/VirtoCommerce.Xapi.Core/Schemas/StorePluginType.cs
+++ b/src/VirtoCommerce.Xapi.Core/Schemas/StorePluginType.cs
@@ -1,0 +1,17 @@
+using GraphQL.Types;
+using VirtoCommerce.Xapi.Core.Models;
+
+namespace VirtoCommerce.Xapi.Core.Schemas;
+
+public class StorePluginType : ExtendableGraphType<StorePlugin>
+{
+    public StorePluginType()
+    {
+        Field(x => x.Id, nullable: false).Description("Plugin ID");
+        Field(x => x.Version, nullable: true).Description("Plugin version");
+        Field(x => x.Permission, nullable: true).Description("Permission the consuming SPA evaluates before loading the plugin");
+        Field<StorePluginFileType>(nameof(StorePlugin.Entry)).Description("The plugin's entry asset (its remoteEntry.js)").Resolve(context => context.Source.Entry);
+        Field<NonNullGraphType<ListGraphType<NonNullGraphType<StorePluginFileType>>>>(nameof(StorePlugin.ContentFiles)).Description("Additional assets the plugin ships").Resolve(context => context.Source.ContentFiles);
+        Field<StorePluginRemoteType>(nameof(StorePlugin.Remote)).Description("Module Federation remote coordinates").Resolve(context => context.Source.Remote);
+    }
+}

--- a/src/VirtoCommerce.Xapi.Core/Schemas/StoreResponseType.cs
+++ b/src/VirtoCommerce.Xapi.Core/Schemas/StoreResponseType.cs
@@ -1,4 +1,7 @@
+using System.Linq;
+using GraphQL;
 using GraphQL.Types;
+using VirtoCommerce.Platform.Core.Modularity;
 using VirtoCommerce.Xapi.Core.Models;
 using VirtoCommerce.Xapi.Core.Services;
 
@@ -6,7 +9,7 @@ namespace VirtoCommerce.Xapi.Core.Schemas
 {
     public class StoreResponseType : ExtendableGraphType<StoreResponse>
     {
-        public StoreResponseType(IDynamicPropertyResolverService dynamicPropertyResolverService)
+        public StoreResponseType(IDynamicPropertyResolverService dynamicPropertyResolverService, IAppManifestService appManifestService)
         {
             Field(x => x.StoreId, nullable: false).Description("Store ID");
             Field(x => x.StoreName, nullable: false).Description("Store name");
@@ -24,6 +27,16 @@ namespace VirtoCommerce.Xapi.Core.Schemas
             Field<NonNullGraphType<GraphQLSettingsType>>(nameof(StoreResponse.GraphQLSettings)).Description("GraphQL settings").Resolve(context => context.Source.GraphQLSettings);
 
             Field<ListGraphType<DynamicPropertyValueType>>(nameof(StoreResponse.DynamicProperties)).Description("Store dynamic property values").Resolve(context => context.Source.DynamicProperties);
+
+            Field<NonNullGraphType<ListGraphType<NonNullGraphType<StorePluginType>>>>("plugins")
+                .Argument<StringGraphType>("appId", $"Frontend host app id whose plugins to return.")
+                .Resolve(context =>
+                {
+                    var appId = context.GetArgument<string>("appId");
+
+                    var manifest = appManifestService.GetManifest(appId);
+                    return manifest?.Plugins.Select(StorePlugin.FromDescriptor).ToList() ?? [];
+                });
         }
     }
 }

--- a/src/VirtoCommerce.Xapi.Core/Schemas/StoreResponseType.cs
+++ b/src/VirtoCommerce.Xapi.Core/Schemas/StoreResponseType.cs
@@ -35,7 +35,7 @@ namespace VirtoCommerce.Xapi.Core.Schemas
                     var appId = context.GetArgument<string>("appId");
 
                     var manifest = appManifestService.GetManifest(appId);
-                    return manifest?.Plugins.Select(StorePlugin.FromDescriptor).ToList() ?? [];
+                    return manifest?.Plugins?.Select(StorePlugin.FromDescriptor).ToList() ?? [];
                 });
         }
     }

--- a/tests/VirtoCommerce.Xapi.Tests/Models/StorePluginMappingTests.cs
+++ b/tests/VirtoCommerce.Xapi.Tests/Models/StorePluginMappingTests.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using VirtoCommerce.Platform.Core.Modularity;
+using VirtoCommerce.Xapi.Core.Models;
+using Xunit;
+
+namespace VirtoCommerce.Xapi.Tests.Models
+{
+    public class StorePluginMappingTests
+    {
+        [Fact]
+        public void FromDescriptor_ShouldMapAllFields()
+        {
+            // Arrange
+            var descriptor = new PluginDescriptor
+            {
+                Id = "VirtoCommerce.Sample",
+                Version = "1.2.3",
+                Permission = "sample:access",
+                Entry = new ContentFileDescriptor { Type = "script", Path = "/modules/$(VirtoCommerce.Sample)/plugins/vc-frontend/remoteEntry.js", Hash = "ABC123" },
+                ContentFiles = new List<ContentFileDescriptor>
+                {
+                    new() { Type = "style", Path = "/modules/$(VirtoCommerce.Sample)/plugins/vc-frontend/style.css", Hash = "DEF456" },
+                },
+                Remote = new PluginRemoteDescriptor { Name = "VirtoCommerce.Sample", Exposed = "./Module" },
+            };
+
+            // Act
+            var result = StorePlugin.FromDescriptor(descriptor);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Id.Should().Be("VirtoCommerce.Sample");
+            result.Version.Should().Be("1.2.3");
+            result.Permission.Should().Be("sample:access");
+            result.Entry.Should().NotBeNull();
+            result.Entry.Type.Should().Be("script");
+            result.Entry.Path.Should().Be("/modules/$(VirtoCommerce.Sample)/plugins/vc-frontend/remoteEntry.js");
+            result.Entry.Hash.Should().Be("ABC123");
+            result.ContentFiles.Should().HaveCount(1);
+            result.ContentFiles[0].Type.Should().Be("style");
+            result.ContentFiles[0].Path.Should().Be("/modules/$(VirtoCommerce.Sample)/plugins/vc-frontend/style.css");
+            result.Remote.Should().NotBeNull();
+            result.Remote.Name.Should().Be("VirtoCommerce.Sample");
+            result.Remote.Exposed.Should().Be("./Module");
+        }
+
+        [Fact]
+        public void FromDescriptor_ShouldReturnNull_WhenDescriptorIsNull()
+        {
+            // Act & Assert
+            StorePlugin.FromDescriptor(null).Should().BeNull();
+        }
+
+        [Fact]
+        public void FromDescriptor_ShouldTolerateMissingOptionalParts()
+        {
+            // Arrange
+            var descriptor = new PluginDescriptor
+            {
+                Id = "VirtoCommerce.Minimal",
+                Version = "1.0.0",
+                // No Entry, no ContentFiles, no Remote, no Permission.
+                ContentFiles = null,
+            };
+
+            // Act
+            var result = StorePlugin.FromDescriptor(descriptor);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Id.Should().Be("VirtoCommerce.Minimal");
+            result.Entry.Should().BeNull();
+            result.Remote.Should().BeNull();
+            result.Permission.Should().BeNull();
+            result.ContentFiles.Should().NotBeNull().And.BeEmpty();
+        }
+    }
+}

--- a/tests/VirtoCommerce.Xapi.Tests/Schemas/StoreResponseTypePluginsTests.cs
+++ b/tests/VirtoCommerce.Xapi.Tests/Schemas/StoreResponseTypePluginsTests.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GraphQL;
+using GraphQL.Execution;
+using Moq;
+using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.Platform.Core.Modularity;
+using VirtoCommerce.Xapi.Core.Models;
+using VirtoCommerce.Xapi.Core.Schemas;
+using VirtoCommerce.Xapi.Core.Services;
+using Xunit;
+
+namespace VirtoCommerce.Xapi.Tests.Schemas
+{
+    public class StoreResponseTypePluginsTests
+    {
+        private readonly Mock<IAppManifestService> _appManifestService = new();
+        private readonly StoreResponseType _storeResponseType;
+
+        public StoreResponseTypePluginsTests()
+        {
+            _storeResponseType = new StoreResponseType(Mock.Of<IDynamicPropertyResolverService>(), _appManifestService.Object);
+        }
+
+        [Fact]
+        public async Task Plugins_ShouldUseProvidedAppId()
+        {
+            // Arrange
+            _appManifestService.Setup(x => x.GetManifest("custom-app"))
+                .Returns(new AppManifestDescriptor { Plugins = [new PluginDescriptor { Id = "VirtoCommerce.Custom" }] });
+            var context = new ResolveFieldContext<StoreResponse>
+            {
+                Source = new StoreResponse(),
+                Arguments = new Dictionary<string, ArgumentValue> { ["appId"] = new ArgumentValue("custom-app", ArgumentSource.Literal) },
+            };
+
+            // Act
+            var result = await ResolvePluginsAsync(context);
+
+            // Assert
+            _appManifestService.Verify(x => x.GetManifest("custom-app"), Times.Once);
+            result.Should().ContainSingle().Which.Id.Should().Be("VirtoCommerce.Custom");
+        }
+
+        [Fact]
+        public async Task Plugins_ShouldReturnEmptyList_WhenManifestIsNull()
+        {
+            // Arrange
+            _appManifestService.Setup(x => x.GetManifest(It.IsAny<string>())).Returns((AppManifestDescriptor)null);
+            var context = new ResolveFieldContext<StoreResponse> { Source = new StoreResponse() };
+
+            // Act
+            var result = await ResolvePluginsAsync(context);
+
+            // Assert
+            result.Should().NotBeNull().And.BeEmpty();
+        }
+
+        private async Task<IList<StorePlugin>> ResolvePluginsAsync(IResolveFieldContext<StoreResponse> context)
+        {
+            var field = _storeResponseType.Fields.FirstOrDefault(x => x.Name.EqualsIgnoreCase("plugins"));
+            field.Should().NotBeNull();
+            var result = await field.Resolver.ResolveAsync(context);
+            return ((IEnumerable<StorePlugin>)result).ToList();
+        }
+    }
+}

--- a/tests/VirtoCommerce.Xapi.Tests/Schemas/StoreResponseTypePluginsTests.cs
+++ b/tests/VirtoCommerce.Xapi.Tests/Schemas/StoreResponseTypePluginsTests.cs
@@ -58,6 +58,21 @@ namespace VirtoCommerce.Xapi.Tests.Schemas
             result.Should().NotBeNull().And.BeEmpty();
         }
 
+        [Fact]
+        public async Task Plugins_ShouldReturnEmptyList_WhenManifestHasNullPlugins()
+        {
+            // Arrange - manifest present but its Plugins collection is null
+            _appManifestService.Setup(x => x.GetManifest(It.IsAny<string>()))
+                .Returns(new AppManifestDescriptor { Plugins = null });
+            var context = new ResolveFieldContext<StoreResponse> { Source = new StoreResponse() };
+
+            // Act
+            var result = await ResolvePluginsAsync(context);
+
+            // Assert
+            result.Should().NotBeNull().And.BeEmpty();
+        }
+
         private async Task<IList<StorePlugin>> ResolvePluginsAsync(IResolveFieldContext<StoreResponse> context)
         {
             var field = _storeResponseType.Fields.FirstOrDefault(x => x.Name.EqualsIgnoreCase("plugins"));


### PR DESCRIPTION
## Description
feat: Extends store with plugins so that the frontend application can request available plugins and run using module federation.

```graphql
query InitializeApplication($domain: String!) {
  store(domain: $domain) {
    storeUrl
    
    plugins(appId:"vc-frontend") 
    {
      id 
      version 
      permission
      entry {type path}
      remote { name exposed}
      contentFiles {hash path} 
    }
    
  }
}
```

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5159
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Xapi_3.1016.0-pr-78-3ce9.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive GraphQL field and read-only manifest projection with tests; no auth or data mutation paths changed.
> 
> **Overview**
> Adds **Module Federation plugin discovery** on the store GraphQL type so frontends can load remotes at startup (e.g. `plugins(appId: "system-operations")` on `store`).
> 
> Introduces XAPI models (`StorePlugin`, assets, remote coordinates) mapped from platform `PluginDescriptor` via `StorePlugin.FromDescriptor`, plus matching GraphQL types. `StoreResponseType` now takes `IAppManifestService` and resolves plugins from the manifest for the given `appId`, returning an empty list when the manifest or plugin list is missing.
> 
> Unit tests cover descriptor mapping (including null/optional fields) and the `plugins` field resolver behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ce90a34577ff0fa22e947b4eb795f025bc1d404. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->