### PR TITLE
VCST-5640: Give each bound property its own index model binder

### DIFF
--- a/src/VirtoCommerce.Xapi.Core/Binding/BoundProperty.cs
+++ b/src/VirtoCommerce.Xapi.Core/Binding/BoundProperty.cs
@@ -1,0 +1,15 @@
+using System.Reflection;
+
+namespace VirtoCommerce.Xapi.Core.Binding
+{
+    /// <summary>
+    /// A property that carries an index model binder, paired with the binder resolved for it.
+    /// <see cref="Binder"/> is never null.
+    /// </summary>
+    public readonly struct BoundProperty(PropertyInfo property, IIndexModelBinder binder)
+    {
+        public PropertyInfo Property { get; } = property;
+
+        public IIndexModelBinder Binder { get; } = binder;
+    }
+}

--- a/src/VirtoCommerce.Xapi.Core/Binding/GenericModelBinder.cs
+++ b/src/VirtoCommerce.Xapi.Core/Binding/GenericModelBinder.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.SearchModule.Core.Model;
 
@@ -11,16 +10,10 @@ namespace VirtoCommerce.Xapi.Core.Binding
         public virtual object BindModel(SearchDocument searchDocument)
         {
             var result = AbstractTypeFactory<TResult>.TryCreateInstance();
-            var properties = result.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance);
 
-            foreach (var property in properties)
+            foreach (var boundProperty in result.GetType().GetBoundProperties())
             {
-                var binder = property.GetIndexModelBinder();
-
-                if (binder != null)
-                {
-                    property.SetValue(result, binder.BindModel(searchDocument));
-                }
+                boundProperty.Property.SetValue(result, boundProperty.Binder.BindModel(searchDocument));
             }
 
             return result;

--- a/src/VirtoCommerce.Xapi.Core/Binding/TypeExtensions.cs
+++ b/src/VirtoCommerce.Xapi.Core/Binding/TypeExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
 
@@ -7,8 +8,7 @@ namespace VirtoCommerce.Xapi.Core.Binding
 {
     public static class TypeExtensions
     {
-
-        private static ConcurrentDictionary<Type, IIndexModelBinder> _bindersCache = new ConcurrentDictionary<Type, IIndexModelBinder>();
+        private static readonly ConcurrentDictionary<Type, ImmutableArray<BoundProperty>> _boundPropertiesCache = new ConcurrentDictionary<Type, ImmutableArray<BoundProperty>>();
 
         public static IIndexModelBinder GetIndexModelBinder(this Type type, IIndexModelBinder defaultBinder)
         {
@@ -17,7 +17,7 @@ namespace VirtoCommerce.Xapi.Core.Binding
 
             if (bindAttr != null)
             {
-                result = GetBinder(bindAttr);
+                result = CreateBinder(bindAttr);
             }
             if (result != null)
             {
@@ -26,32 +26,59 @@ namespace VirtoCommerce.Xapi.Core.Binding
             return result;
         }
 
+        /// <summary>
+        /// A binder configured for <paramref name="propInfo"/>, created fresh on every call so that the
+        /// caller owns it outright — nothing else reads the returned instance, including its
+        /// <see cref="IIndexModelBinder.BindingInfo"/>. Null when the property declares no binder.
+        /// Prefer <see cref="GetBoundProperties"/>, which resolves a whole type once.
+        /// </summary>
         public static IIndexModelBinder GetIndexModelBinder(this PropertyInfo propInfo)
         {
-            IIndexModelBinder result = null;
+            return CreateBinder(propInfo);
+        }
+
+        /// <summary>
+        /// The public instance properties of <paramref name="type"/> that carry a binder, each paired with
+        /// its binder, cached against the type — pass the runtime type so an <c>AbstractTypeFactory</c>
+        /// override is described by its own entry rather than by its base's.
+        /// <para>Each paired binder is shared by every document bound through it, so a binder
+        /// implementation must keep no per-call state — and a caller must not write to the binder or to
+        /// its <see cref="IIndexModelBinder.BindingInfo"/>, which would retarget that property for every
+        /// thread. Use <see cref="GetIndexModelBinder(PropertyInfo)"/> for an instance you own.</para>
+        /// </summary>
+        public static ImmutableArray<BoundProperty> GetBoundProperties(this Type type)
+        {
+            return _boundPropertiesCache.GetOrAdd(type, x => x
+                .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Select(propInfo => new BoundProperty(propInfo, propInfo.GetIndexModelBinder()))
+                .Where(boundProperty => boundProperty.Binder != null)
+                .ToImmutableArray());
+        }
+
+        private static IIndexModelBinder CreateBinder(PropertyInfo propInfo)
+        {
             var bindAttr = propInfo.GetCustomAttributes<BindIndexFieldAttribute>().FirstOrDefault();
 
-            if (bindAttr != null)
+            if (bindAttr == null)
             {
-                result = GetBinder(bindAttr);
+                return null;
             }
+
+            var result = CreateBinder(bindAttr);
+
             if (result != null)
             {
-                result.BindingInfo = propInfo.GetBindingInfo() ?? result.BindingInfo;
+                result.BindingInfo = GetBindingInfo(bindAttr) ?? result.BindingInfo;
             }
+
             return result;
         }
 
-        private static BindingInfo GetBindingInfo(this PropertyInfo propInfo)
+        private static IIndexModelBinder CreateBinder(BindIndexFieldAttribute attr)
         {
-            BindingInfo result = null;
-            var bindAttr = propInfo.GetCustomAttributes<BindIndexFieldAttribute>().FirstOrDefault();
+            var binderType = attr.BinderType ?? typeof(DefaultPropertyIndexBinder);
 
-            if (bindAttr != null)
-            {
-                result = GetBindingInfo(bindAttr);
-            }
-            return result;
+            return Activator.CreateInstance(binderType) as IIndexModelBinder;
         }
 
         private static BindingInfo GetBindingInfo(this Type type)
@@ -72,16 +99,6 @@ namespace VirtoCommerce.Xapi.Core.Binding
             {
                 FieldName = attr.FieldName
             };
-        }
-
-        private static IIndexModelBinder GetBinder(BindIndexFieldAttribute attr)
-        {
-            var binderType = attr.BinderType;
-            if (binderType == null)
-            {
-                binderType = typeof(DefaultPropertyIndexBinder);
-            }
-            return _bindersCache.GetOrAdd(binderType, type => Activator.CreateInstance(binderType) as IIndexModelBinder);
         }
     }
 }

--- a/tests/VirtoCommerce.Xapi.Tests/Binding/IndexModelBinderSharedStateTests.cs
+++ b/tests/VirtoCommerce.Xapi.Tests/Binding/IndexModelBinderSharedStateTests.cs
@@ -1,0 +1,109 @@
+using System.Linq;
+using FluentAssertions;
+using VirtoCommerce.Xapi.Core.Binding;
+using Xunit;
+
+namespace VirtoCommerce.Xapi.Tests.Binding;
+
+public class IndexModelBinderSharedStateTests
+{
+    private const string FieldA = "field_a";
+    private const string FieldB = "field_b";
+
+    public class TwoFieldsModel
+    {
+        [BindIndexField(FieldName = FieldA, BinderType = typeof(DefaultPropertyIndexBinder))]
+        public object A { get; set; }
+
+        [BindIndexField(FieldName = FieldB, BinderType = typeof(DefaultPropertyIndexBinder))]
+        public object B { get; set; }
+
+        public object NotBound { get; set; }
+    }
+
+    /// <summary>
+    /// A binder reads its field name off its own instance, so two properties sharing a binder type must
+    /// not share the instance: resolving one would retarget the other's field name, and a concurrent
+    /// bind would then read a property from the wrong index field. Caching per binder type did exactly
+    /// that — measured as one property receiving another's value under eight threads.
+    /// </summary>
+    [Fact]
+    public void GetIndexModelBinder_TwoPropertiesSharingABinderType_KeepsTheirFieldNamesIndependent()
+    {
+        var propertyA = typeof(TwoFieldsModel).GetProperty(nameof(TwoFieldsModel.A));
+        var propertyB = typeof(TwoFieldsModel).GetProperty(nameof(TwoFieldsModel.B));
+
+        var binderA = propertyA.GetIndexModelBinder();
+        var binderB = propertyB.GetIndexModelBinder();
+
+        binderB.Should().NotBeSameAs(binderA);
+        binderA.BindingInfo.FieldName.Should().Be(FieldA);
+        binderB.BindingInfo.FieldName.Should().Be(FieldB);
+    }
+
+    /// <summary>
+    /// The caller owns what it gets back. Handing out a shared instance would put a public setter on
+    /// process-wide state — a smaller copy of the defect this class exists to pin down.
+    /// </summary>
+    [Fact]
+    public void GetIndexModelBinder_SameProperty_ReturnsAnInstanceTheCallerOwns()
+    {
+        var property = typeof(TwoFieldsModel).GetProperty(nameof(TwoFieldsModel.A));
+
+        var first = property.GetIndexModelBinder();
+        var second = property.GetIndexModelBinder();
+
+        second.Should().NotBeSameAs(first);
+
+        first.BindingInfo.FieldName = "rewritten";
+
+        property.GetIndexModelBinder().BindingInfo.FieldName.Should().Be(FieldA);
+    }
+
+    /// <summary>
+    /// The type-level cache is the whole optimization: applying the "an instance the caller owns" rule
+    /// above to this path too would silently restore per-document binder construction, with every test
+    /// still green.
+    /// </summary>
+    [Fact]
+    public void GetBoundProperties_CalledTwice_ReusesTheSameBinders()
+    {
+        var first = typeof(TwoFieldsModel).GetBoundProperties();
+        var second = typeof(TwoFieldsModel).GetBoundProperties();
+
+        second.Select(x => x.Binder).Should().Equal(first.Select(x => x.Binder));
+    }
+
+    /// <summary>
+    /// Callers bind every returned pair unguarded, so a property without a binder must never appear:
+    /// its null binder would throw on the first document of every request.
+    /// </summary>
+    [Fact]
+    public void GetBoundProperties_ExcludesPropertiesWithoutABinder()
+    {
+        var boundProperties = typeof(TwoFieldsModel).GetBoundProperties();
+
+        boundProperties.Select(x => x.Property.Name).Should().BeEquivalentTo([nameof(TwoFieldsModel.A), nameof(TwoFieldsModel.B)]);
+        boundProperties.Should().OnlyContain(x => x.Binder != null);
+    }
+
+    /// <summary>
+    /// The pair carries the binder the property resolves to, so the caller never looks it up a second time.
+    /// </summary>
+    [Fact]
+    public void GetBoundProperties_PairsEachPropertyWithItsOwnBinder()
+    {
+        var boundProperties = typeof(TwoFieldsModel).GetBoundProperties();
+
+        foreach (var boundProperty in boundProperties)
+        {
+            boundProperty.Binder.BindingInfo.FieldName.Should().Be(boundProperty.Property.Name == nameof(TwoFieldsModel.A) ? FieldA : FieldB);
+        }
+    }
+
+    [Fact]
+    public void GetBoundProperties_TypeWithNoAttributedProperty_ReturnsEmpty()
+    {
+        typeof(BindingInfo).GetBoundProperties().Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
Part of [VCST-5640](https://virtocommerce.atlassian.net/browse/VCST-5640). Companion to [vc-module-x-catalog PR 107](https://github.com/VirtoCommerce/vc-module-x-catalog/pull/107); this half is independent and can merge on its own.

## A data race on the shared binder instance

`TypeExtensions` cached `IIndexModelBinder` instances keyed by **binder type**, so every property declaring the same `BinderType` shared one process-wide instance. `GetIndexModelBinder` then assigned `BindingInfo` onto that shared instance immediately before the caller invoked `BindModel`, which reads the field name back off its own state.

Two properties with the same binder and different field names therefore race: resolving the second retargets the first, and a concurrent bind reads a property from the wrong index field. No exception, no log line, a plausible-looking value.

This is reachable from shipped client code — a model routing several properties through `DefaultPropertyIndexBinder` with distinct field names is the normal way to use the attribute. Reproduced before the change with eight threads binding a two-field model: a property came back holding the other property's value.

## The fix

`GetBoundProperties` resolves a type's attributed properties once and caches each one paired with its own binder, whose `BindingInfo` is written at creation and never reassigned. The trade the old cache made — save an allocation, pay with shared mutable state — is inverted: one binder per attributed property, written once.

Nothing depended on the sharing. Every `IIndexModelBinder` implementation in the platform and in the client modules holds no mutable instance state besides `BindingInfo`, and `_bindersCache` was private.

`GetIndexModelBinder(PropertyInfo)` is deliberately left uncached and returns a fresh binder per call. It is public API and `BindingInfo` has a public setter, so a memoized instance would be a shared mutable object handed to callers — a smaller copy of the defect above, prevented by a doc comment instead of by construction. The instances that must be shared live in the pair cache, where nothing writes to them after publication and the xmldoc states the obligation on both sides.

The committed test asserts the invariant deterministically — that two properties sharing a binder type keep independent field names — rather than asserting the absence of a threading symptom. It was confirmed red against per-binder-type caching and green after. The eight-thread reproduction did its job and was deliberately left out of the suite: a probabilistic assertion of absence is a poor gate.

## The same cache removes the per-document reflection

`GenericModelBinder` walked every public instance property of the bound type and called `GetCustomAttributes` on each, once per bound document, to find the handful that carry a binder. `GetBoundProperties` returns just those — each already paired with its binder, so the caller never resolves one a second time — cached against the **runtime** type, so an `AbstractTypeFactory` override is described by its own entry and continues to behave exactly as it does today, including one that adds `[BindIndexField]` of its own.

The identical loop is copied into x-catalog's `CatalogProductBinder`, where it runs a second time per product document. Measured there on the real `CatalogProduct`: about 800 B per document — 528 B for the `GetProperties` array plus 288 B of attribute lookups — all of it to find binders that type does not have.

Order is preserved (`Select`/`Where` do not reorder), and the bound set is identical to what the old loop produced.

To be exact about who benefits when: x-catalog keeps its own copy of the loop and calls `GetIndexModelBinder(PropertyInfo)` per property per document. Measured on the real `CatalogProduct` — 63 public properties, none carrying `[BindIndexField]` — that loop costs 288 B per document both before and after this commit, so nothing there regresses and nothing there improves until that module adopts `GetBoundProperties`. Properties with no attribute cost nothing (`GetCustomAttributes` returns a cached empty array); the 288 B comes from the six properties carrying some other attribute.

## Notes for the reviewer

- `GetIndexModelBinder(Type, IIndexModelBinder)` — the class-level overload — now receives a fresh binder rather than the shared cached one, which removes the same corruption risk from it. It has no caller in any VirtoCommerce repo and there is no class-level `[BindIndexField]` usage, but it is public API, so an external caller in a hot path would now allocate per call.
- `GetBoundProperties` returns `ImmutableArray` deliberately: it hands out the cached instance, and a caller who downcast an `IReadOnlyList` back to the array and wrote into a slot would corrupt every later bind of that type process-wide. It also keeps the per-document `foreach` allocation-free.
- The cache is bounded by the `AbstractTypeFactory` registry, which is fixed after module startup.
- The x-catalog copy of the loop cannot adopt `GetBoundProperties` until this ships — that module consumes `VirtoCommerce.Xapi.Core` as a package (currently pinned at 3.1015.0) — so switching it over is a follow-up, and until then its ~800 B per document stays exactly as it is today.


[VCST-5640]: https://virtocommerce.atlassian.net/browse/VCST-5640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Xapi_3.1017.0-pr-79-804e.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core search document binding on every bound model; behavior change is intentional (correctness) but affects hot paths and shared binder contract documented for callers.
> 
> **Overview**
> Fixes a **concurrency bug** where `IIndexModelBinder` instances were cached by binder type, so multiple `[BindIndexField]` properties sharing the same `BinderType` mutated one shared `BindingInfo` and could bind the wrong search field under load.
> 
> **Binding resolution** now allocates **one binder per attributed property** (field name set at creation). `GetBoundProperties` caches an `ImmutableArray` of `BoundProperty` pairs per runtime type; `GenericModelBinder` binds via that list instead of reflecting every property on each document. `GetIndexModelBinder(PropertyInfo)` stays **uncached** and returns a caller-owned instance so public `BindingInfo` mutation cannot leak process-wide state.
> 
> Adds **`IndexModelBinderSharedStateTests`** to lock in independent field names, cache reuse, and filtering of unbound properties.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 804e5d7663f262b86323600edbe51f9a3cfc1b4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->