### PR TITLE
feat: Let the caller extend the MediatR configuration AddSchema builds

### DIFF
--- a/docs/x-api-extensions.md
+++ b/docs/x-api-extensions.md
@@ -111,6 +111,26 @@ The system uses Platform's abstract type factory to instantiate validators. Ther
 ```
 
 
+## Run MediatR request pre-processors
+`AddSchema` registers your module's assembly with MediatR. To enable options that registration depends on, pass a configuration callback instead of calling `AddMediatR` yourself:
+
+```csharp
+builder.AddSchema(services, typeof(AssemblyMarker), cfg =>
+{
+    cfg.AutoRegisterRequestProcessors = true;
+    cfg.AddOpenBehavior(typeof(RequestPreProcessorBehavior<,>));
+});
+```
+
+Both lines are needed: the flag registers the `IRequestPreProcessor<>` implementations, `AddOpenBehavior` registers the pipeline stage that invokes them. With the flag alone they sit in the container and nothing calls them — no error, no log.
+
+Prefer the callback to a second `AddMediatR` over the same assembly: request handlers dedupe, notification handlers do not and would run twice.
+
+Use it for additive registration — behaviors, processors, extra assemblies. Container-wide options such as `Lifetime`, `MediatorImplementationType` and `NotificationPublisher` are applied with `TryAdd`, so the first module to call `AddSchema` wins and every later module's value is silently ignored.
+
+This is MediatR's own pipeline, not the `AddPipeline<T>` middleware chains described below.
+
+
 ## Generic behavior pipelines
 xAPI extension points are not limited to data structure extensions. You can also change behavior and business logic outside from  the your custom module without touching the original source code.
 

--- a/src/VirtoCommerce.Xapi.Core/Extensions/GraphQLBuilderExtensions.cs
+++ b/src/VirtoCommerce.Xapi.Core/Extensions/GraphQLBuilderExtensions.cs
@@ -48,9 +48,18 @@ namespace VirtoCommerce.Xapi.Core.Extensions
 
         public static IGraphQLBuilder AddSchema(this IGraphQLBuilder builder, IServiceCollection services, Type assemblyMarker)
         {
+            return builder.AddSchema(services, assemblyMarker, configureMediatR: null);
+        }
+
+        public static IGraphQLBuilder AddSchema(this IGraphQLBuilder builder, IServiceCollection services, Type assemblyMarker, Action<MediatRServiceConfiguration> configureMediatR)
+        {
             builder.AddGraphTypes(assemblyMarker.Assembly);
             builder.AddOptionalGraphTypes(assemblyMarker);
-            services.AddMediatR(configuration => configuration.RegisterServicesFromAssembly(assemblyMarker.Assembly));
+            services.AddMediatR(configuration =>
+            {
+                configuration.RegisterServicesFromAssembly(assemblyMarker.Assembly);
+                configureMediatR?.Invoke(configuration);
+            });
             services.AddAutoMapper(assemblyMarker);
             services.AddSchemaBuilders(assemblyMarker);
 
@@ -59,9 +68,18 @@ namespace VirtoCommerce.Xapi.Core.Extensions
 
         public static IGraphQLBuilder AddSchema(this IGraphQLBuilder builder, IServiceCollection services, Type coreAssemblyMarker, Type dataAssemblyMarker)
         {
+            return builder.AddSchema(services, coreAssemblyMarker, dataAssemblyMarker, configureMediatR: null);
+        }
+
+        public static IGraphQLBuilder AddSchema(this IGraphQLBuilder builder, IServiceCollection services, Type coreAssemblyMarker, Type dataAssemblyMarker, Action<MediatRServiceConfiguration> configureMediatR)
+        {
             builder.AddGraphTypes(coreAssemblyMarker.Assembly);
             builder.AddOptionalGraphTypes(coreAssemblyMarker);
-            services.AddMediatR(configuration => configuration.RegisterServicesFromAssemblies(coreAssemblyMarker.Assembly, dataAssemblyMarker.Assembly));
+            services.AddMediatR(configuration =>
+            {
+                configuration.RegisterServicesFromAssemblies(coreAssemblyMarker.Assembly, dataAssemblyMarker.Assembly);
+                configureMediatR?.Invoke(configuration);
+            });
             services.AddAutoMapper(coreAssemblyMarker, dataAssemblyMarker);
             services.AddSchemaBuilders(dataAssemblyMarker);
 

--- a/tests/VirtoCommerce.Xapi.Tests/Extensions/GraphQLBuilderExtensionsTests.cs
+++ b/tests/VirtoCommerce.Xapi.Tests/Extensions/GraphQLBuilderExtensionsTests.cs
@@ -1,0 +1,66 @@
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GraphQL;
+using MediatR;
+using MediatR.Pipeline;
+using Microsoft.Extensions.DependencyInjection;
+using VirtoCommerce.Xapi.Core.Extensions;
+using Xunit;
+
+namespace VirtoCommerce.Xapi.Tests.Extensions
+{
+    public class GraphQLBuilderExtensionsTests
+    {
+        [Fact]
+        public async Task AddSchema_ConfigureMediatREnablesPreProcessors_PreProcessorRunsBeforeHandler()
+        {
+            var services = new ServiceCollection();
+            services.AddGraphQL(builder => builder.AddSchema(services, typeof(GraphQLBuilderExtensionsTests), cfg =>
+            {
+                cfg.AutoRegisterRequestProcessors = true;
+                cfg.AddOpenBehavior(typeof(RequestPreProcessorBehavior<,>));
+            }));
+
+            var result = await services.BuildServiceProvider().GetRequiredService<IMediator>().Send(new ProbeRequest());
+
+            result.Should().Be(ProbeRequestPreProcessor.Marker);
+        }
+
+        [Fact]
+        public async Task AddSchema_WithoutConfigureMediatR_HandlerRunsAndPreProcessorDoesNot()
+        {
+            var services = new ServiceCollection();
+            services.AddGraphQL(builder => builder.AddSchema(services, typeof(GraphQLBuilderExtensionsTests)));
+
+            var result = await services.BuildServiceProvider().GetRequiredService<IMediator>().Send(new ProbeRequest());
+
+            result.Should().BeNull();
+        }
+    }
+
+    public class ProbeRequest : IRequest<string>
+    {
+        public string Marker { get; set; }
+    }
+
+    public class ProbeRequestHandler : IRequestHandler<ProbeRequest, string>
+    {
+        public Task<string> Handle(ProbeRequest request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(request.Marker);
+        }
+    }
+
+    public class ProbeRequestPreProcessor : IRequestPreProcessor<ProbeRequest>
+    {
+        public const string Marker = "pre-processed";
+
+        public Task Process(ProbeRequest request, CancellationToken cancellationToken)
+        {
+            request.Marker = Marker;
+
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## Description

`AddSchema` is the only place that registers a client x-module's assembly with MediatR, and it kept that configuration to itself. A module needing an option the registration depends on — `AutoRegisterRequestProcessors`, an open behavior — had no way in: its only recourse was to call `AddMediatR` a second time over the same assembly. On that second scan request handlers dedupe via `TryAddTransient`, but `INotificationHandler`, `IRequestExceptionHandler` and `IRequestExceptionAction` are registered with a plain `AddTransient`, so they are registered twice and run twice.

Both `AddSchema` overloads gain a sibling taking `Action<MediatRServiceConfiguration>`, applied to the same configuration the assembly is registered with. No second scan is needed.

`docs/x-api-extensions.md` gains a short section covering the callback and the two-call recipe pre-processors need.

No schema change / no migrations / no new settings / no new dependencies.

## New GraphQL queries and mutations

None — this PR adds no query or mutation.

## Changes to existing GraphQL queries and mutations

None.

## New public services / interfaces / methods

Two `GraphQLBuilderExtensions.AddSchema` overloads:

```csharp
AddSchema(IGraphQLBuilder, IServiceCollection, Type assemblyMarker, Action<MediatRServiceConfiguration> configureMediatR)
AddSchema(IGraphQLBuilder, IServiceCollection, Type coreAssemblyMarker, Type dataAssemblyMarker, Action<MediatRServiceConfiguration> configureMediatR)
```

Use the callback to enable MediatR options your module's registration depends on:

```csharp
builder.AddSchema(services, typeof(AssemblyMarker), cfg =>
{
    cfg.AutoRegisterRequestProcessors = true;
    cfg.AddOpenBehavior(typeof(RequestPreProcessorBehavior<,>));
});
```

Both lines are needed. `AutoRegisterRequestProcessors` registers the `IRequestPreProcessor<>` implementations; `RequestPreProcessorBehavior<,>` is the pipeline stage that invokes them, and MediatR adds it only when `RequestPreProcessorsToRegister` is non-empty, which the auto-scan never populates. With the flag alone the pre-processors sit in the container and nothing calls them — no error, no log.

`null` is accepted and means no extra configuration.

## New protected methods (extensibility)

None.

## Breaking changes

- **Compile** — the existing three- and four-argument overloads keep their exact signatures and now delegate to the new ones. One source-level exception: a bare `null` literal in the trailing position — `builder.AddSchema(services, marker, null)` — becomes ambiguous (CS0121), because the compiler can no longer tell the `(…, Type, Type)` overload from the `(…, Type, Action<…>)` one. No such call site exists in any VirtoCommerce repository checked, and any that did would already have thrown at startup on `dataAssemblyMarker.Assembly`. Workaround: `(Action<MediatRServiceConfiguration>)null`.
- **Package upgrade** — nothing published was removed or renamed. The callback was added as new overloads rather than as an optional parameter precisely for this: an optional parameter's default is baked into the call site, so a consumer compiled against the current signature would fail at runtime with `MissingMethodException` after upgrading.
- **Runtime / behaviour** — none. Without a callback the composed lambda performs the same single registration call as before.

No `[Obsolete]` was introduced: nothing is deprecated.

## New dependencies

None. `MediatRServiceConfiguration` comes from the MediatR package this module already references.

> **Note (scope of the callback)** — it is meant for additive registration: behaviors, processors, extra assemblies. Container-wide options such as `Lifetime`, `MediatorImplementationType` and `NotificationPublisher` are applied with `TryAdd`, so the first module to call `AddSchema` wins and later modules' values are silently ignored. This is documented in `docs/x-api-extensions.md` rather than left to the reader.

> **Note (why a callback rather than enabling the option here)** — turning `AutoRegisterRequestProcessors` on inside `AddSchema` would change DI registration for every existing consumer in one release, including modules that ship no pre-processor. The callback leaves that decision with the module that has the requirement.

## References
### QA-test:
### Jira-link:
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Xapi_3.1019.0-pr-80-4b4f.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive extension API with unchanged default MediatR registration; only edge case is compile-time ambiguity if a bare `null` is passed as the third argument to the two-type `AddSchema` overload.
> 
> **Overview**
> **`AddSchema`** now accepts an optional `Action<MediatRServiceConfiguration>` on both the single-assembly and core/data assembly overloads. The callback runs inside the same `AddMediatR` registration that already scans the module assembly, so extensions can turn on behaviors like request pre-processors without a second `AddMediatR` scan (which would duplicate notification handlers).
> 
> Existing three- and four-argument calls are unchanged and delegate to the new overloads with a `null` callback. **`docs/x-api-extensions.md`** documents the pre-processor recipe and cautions about duplicate registration and first-wins container options.
> 
> Tests assert that with the callback, `IRequestPreProcessor<>` runs before the handler; without it, pre-processors are not invoked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b4f59cb48d0f352eb2cdc816d709c682216b736. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->