### PR TITLE
VCST-5691: Change DiscountPercent rounding

### DIFF
--- a/src/VirtoCommerce.Xapi.Core/Models/ProductPrice.cs
+++ b/src/VirtoCommerce.Xapi.Core/Models/ProductPrice.cs
@@ -22,6 +22,11 @@ namespace VirtoCommerce.Xapi.Core.Models
         }
 
         /// <summary>
+        /// Number of decimal digits in the relative discount value (0.3333 = 33.33%).
+        /// </summary>
+        private const int _discountPercentDecimalDigits = 4;
+
+        /// <summary>
         /// Price list id
         /// </summary>
         public string PricelistId { get; set; }
@@ -48,7 +53,7 @@ namespace VirtoCommerce.Xapi.Core.Models
         /// <summary>
         /// Relative benefit. 30%
         /// </summary>
-        public decimal DiscountPercent => ListPrice.Amount > 0 ? Math.Round(DiscountAmount.Amount / ListPrice.Amount, 2) : 0;
+        public decimal DiscountPercent => GetDiscountPercent();
 
         /// <summary>
         /// Original product price (old price)
@@ -163,6 +168,13 @@ namespace VirtoCommerce.Xapi.Core.Models
         public ICollection<Discount> Discounts { get; set; }
         public DateTime? StartDate { get; set; }
         public DateTime? EndDate { get; set; }
+
+        protected virtual decimal GetDiscountPercent()
+        {
+            return ListPrice.Amount > 0
+                ? Math.Round(DiscountAmount.Amount / ListPrice.Amount, _discountPercentDecimalDigits, MidpointRounding.AwayFromZero)
+                : 0;
+        }
 
         protected override IEnumerable<object> GetEqualityComponents()
         {

--- a/tests/VirtoCommerce.Xapi.Tests/Models/ProductPriceTests.cs
+++ b/tests/VirtoCommerce.Xapi.Tests/Models/ProductPriceTests.cs
@@ -1,0 +1,62 @@
+using System;
+using FluentAssertions;
+using VirtoCommerce.CoreModule.Core.Currency;
+using VirtoCommerce.Xapi.Core.Models;
+using VirtoCommerce.Xapi.Tests.Helpers;
+using Xunit;
+
+namespace VirtoCommerce.Xapi.Tests.Models
+{
+    public class ProductPriceTests : MoqHelper
+    {
+        private const decimal _listPrice = 100m;
+
+        public static TheoryData<decimal, decimal> DiscountAmounts => new()
+        {
+            { 10m, 0.1m },
+            { 12.5m, 0.125m },
+            { 7.5m, 0.075m },
+            { 33.33m, 0.3333m },
+            { 0.5m, 0.005m },
+        };
+
+        [Theory]
+        [MemberData(nameof(DiscountAmounts))]
+        public void ProductPrice_DiscountPercent_ShouldBeRelativeToListPrice(decimal discountAmount, decimal expectedDiscountPercent)
+        {
+            // Arrange
+            var productPrice = GetProductPrice(_listPrice, discountAmount);
+
+            // Act
+            var result = productPrice.DiscountPercent;
+
+            // Assert
+            result.Should().Be(expectedDiscountPercent);
+        }
+
+        [Fact]
+        public void ProductPrice_DiscountPercent_ShouldBeZeroWhenListPriceZero()
+        {
+            // Arrange
+            var productPrice = GetProductPrice(0, 10m);
+
+            // Act
+            var result = productPrice.DiscountPercent;
+
+            // Assert
+            result.Should().Be(0m);
+        }
+
+        private ProductPrice GetProductPrice(decimal listPrice, decimal discountAmount, Action<Currency> configureCurrency = null)
+        {
+            var currency = GetCurrency();
+            configureCurrency?.Invoke(currency);
+
+            return new ProductPrice(currency)
+            {
+                ListPrice = new Money(listPrice, currency),
+                DiscountAmount = new Money(discountAmount, currency),
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5691
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Xapi_3.1017.0-pr-81-d4a4.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes a pricing API value consumers may display or compare; clients expecting 2-decimal DiscountPercent will now receive 4-decimal results.
> 
> **Overview**
> Increases `ProductPrice.DiscountPercent` precision from **2** to **4** decimal places and rounds with `MidpointRounding.AwayFromZero`, aligning with existing tax percent rounding.
> 
> The calculation is moved into a protected virtual `GetDiscountPercent()` method. Unit tests cover common discount ratios and the zero list-price edge case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4a40765e6e457d4a8dd80993a47b8ff0b9f1977. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->