### PR TITLE
VCST-5691: Register ProductPrice with AbstractTypeFactory

### DIFF
--- a/src/VirtoCommerce.Xapi.Web/Module.cs
+++ b/src/VirtoCommerce.Xapi.Web/Module.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
+using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.DeveloperTools;
 using VirtoCommerce.Platform.Core.Modularity;
 using VirtoCommerce.Platform.Core.Settings;
@@ -142,6 +143,9 @@ namespace VirtoCommerce.Xapi.Web
             serviceCollection.Configure<StoresOptions>(Configuration.GetSection(ConfigKeys.Stores));
 
             serviceCollection.AddAuthenticationFilter(Configuration);
+
+            // explicit registration with AbstractTypeFactory to use constructor with arguments
+            AbstractTypeFactory<ProductPrice>.RegisterType<ProductPrice>();
         }
 
         public void PostInitialize(IApplicationBuilder appBuilder)


### PR DESCRIPTION
## Description
To create instances using constructor with arguments.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5691
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Xapi_3.1018.0-alpha.195-vcst-5691.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single startup registration for a pricing model type; no auth, security, or broad behavioral refactors.
> 
> **Overview**
> Registers **`ProductPrice`** with **`AbstractTypeFactory`** during XAPI web module initialization so platform code can create instances via the factory using the **`ProductPrice(Currency)`** constructor instead of relying on a parameterless path.
> 
> Adds the **`VirtoCommerce.Platform.Core.Common`** import needed for **`AbstractTypeFactory`** in **`Module.cs`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0a347b7b5acd05af865605336cb0ea7837cbe3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->