### PR TITLE
VCST-5661: Implemented FacetMappingContext

### DIFF
--- a/src/VirtoCommerce.Xapi.Core/Models/Facets/FacetMappingContext.cs
+++ b/src/VirtoCommerce.Xapi.Core/Models/Facets/FacetMappingContext.cs
@@ -1,8 +1,11 @@
 namespace VirtoCommerce.Xapi.Core.Models.Facets
 {
-    public class FacetMappingContext
+    /// <summary>
+    /// Ambient context for <c>ToFacetResult</c>-style mapping methods. Carries only what is the same
+    /// for every aggregation being mapped in one call (e.g. <see cref="MappingContext.CultureName"/>);
+    /// a per-facet ordinal is not ambient and is a separate method argument instead.
+    /// </summary>
+    public class FacetMappingContext : MappingContext
     {
-        public string CultureName { get; set; }
-        public int? Order { get; set; }
     }
 }

--- a/src/VirtoCommerce.Xapi.Core/Models/Facets/FacetMappingContext.cs
+++ b/src/VirtoCommerce.Xapi.Core/Models/Facets/FacetMappingContext.cs
@@ -1,0 +1,8 @@
+namespace VirtoCommerce.Xapi.Core.Models.Facets
+{
+    public class FacetMappingContext
+    {
+        public string CultureName { get; set; }
+        public int? Order { get; set; }
+    }
+}

--- a/src/VirtoCommerce.Xapi.Core/Models/Facets/FacetMappingContext.cs
+++ b/src/VirtoCommerce.Xapi.Core/Models/Facets/FacetMappingContext.cs
@@ -1,9 +1,14 @@
 namespace VirtoCommerce.Xapi.Core.Models.Facets
 {
     /// <summary>
-    /// Ambient context for <c>ToFacetResult</c>-style mapping methods. Carries only what is the same
-    /// for every aggregation being mapped in one call (e.g. <see cref="MappingContext.CultureName"/>);
-    /// a per-facet ordinal is not ambient and is a separate method argument instead.
+    /// The <see cref="MappingContext"/> override axis shared by every <c>ToFacetResult</c>-style
+    /// mapper (x-catalog, x-order, x-pickup): a common type each of them can register a further
+    /// derivative of, rather than each declaring its own unrelated facet context. It carries only
+    /// what is ambient for every aggregation in one call (currently just
+    /// <see cref="MappingContext.CultureName"/>, inherited); a per-facet ordinal is not ambient and
+    /// stays a separate method argument. It is otherwise empty on purpose, not unfinished: the only
+    /// facet-shaped candidate, <c>TermValuesSortingType</c>, comes off <c>Aggregation</c> itself, so
+    /// it is source data being mapped, not context describing the mapping.
     /// </summary>
     public class FacetMappingContext : MappingContext
     {

--- a/src/VirtoCommerce.Xapi.Core/Models/Facets/FacetMappingContext.cs
+++ b/src/VirtoCommerce.Xapi.Core/Models/Facets/FacetMappingContext.cs
@@ -1,11 +1,10 @@
-namespace VirtoCommerce.Xapi.Core.Models.Facets
+namespace VirtoCommerce.Xapi.Core.Models.Facets;
+
+/// <summary>
+/// Ambient context for <c>ToFacetResult</c>-style mapping methods. Carries only what is the same
+/// for every aggregation being mapped in one call (e.g. <see cref="MappingContext.CultureName"/>);
+/// a per-facet ordinal is not ambient and is a separate method argument instead.
+/// </summary>
+public class FacetMappingContext : MappingContext
 {
-    /// <summary>
-    /// Ambient context for <c>ToFacetResult</c>-style mapping methods. Carries only what is the same
-    /// for every aggregation being mapped in one call (e.g. <see cref="MappingContext.CultureName"/>);
-    /// a per-facet ordinal is not ambient and is a separate method argument instead.
-    /// </summary>
-    public class FacetMappingContext : MappingContext
-    {
-    }
 }

--- a/src/VirtoCommerce.Xapi.Core/Models/Facets/FacetMappingContext.cs
+++ b/src/VirtoCommerce.Xapi.Core/Models/Facets/FacetMappingContext.cs
@@ -1,10 +1,11 @@
-namespace VirtoCommerce.Xapi.Core.Models.Facets;
-
-/// <summary>
-/// Ambient context for <c>ToFacetResult</c>-style mapping methods. Carries only what is the same
-/// for every aggregation being mapped in one call (e.g. <see cref="MappingContext.CultureName"/>);
-/// a per-facet ordinal is not ambient and is a separate method argument instead.
-/// </summary>
-public class FacetMappingContext : MappingContext
+namespace VirtoCommerce.Xapi.Core.Models.Facets
 {
+    /// <summary>
+    /// Ambient context for <c>ToFacetResult</c>-style mapping methods. Carries only what is the same
+    /// for every aggregation being mapped in one call (e.g. <see cref="MappingContext.CultureName"/>);
+    /// a per-facet ordinal is not ambient and is a separate method argument instead.
+    /// </summary>
+    public class FacetMappingContext : MappingContext
+    {
+    }
 }

--- a/src/VirtoCommerce.Xapi.Core/Models/MappingContext.cs
+++ b/src/VirtoCommerce.Xapi.Core/Models/MappingContext.cs
@@ -1,15 +1,16 @@
-namespace VirtoCommerce.Xapi.Core.Models;
-
-/// <summary>
-/// Base type for the ambient context objects X-module mappers take instead of positional
-/// parameters. A member belongs here only if it is the same for every item in the operation
-/// (e.g. culture, currency); per-item values derived from the caller's own iteration (e.g. an
-/// ordinal) do not belong on a context and should stay as separate arguments.
-/// Built via <c>AbstractTypeFactory&lt;T&gt;.TryCreateInstance()</c> so a consumer can register a
-/// derived type with extra ambient fields; populate it through a <c>protected virtual</c> creation
-/// hook on the mapper, not inline at each call site, so overriding it is a one-method change.
-/// </summary>
-public class MappingContext
+namespace VirtoCommerce.Xapi.Core.Models
 {
-    public string CultureName { get; set; }
+    /// <summary>
+    /// Base type for the ambient context objects X-module mappers take instead of positional
+    /// parameters. A member belongs here only if it is the same for every item in the operation
+    /// (e.g. culture, currency); per-item values derived from the caller's own iteration (e.g. an
+    /// ordinal) do not belong on a context and should stay as separate arguments.
+    /// Built via <c>AbstractTypeFactory&lt;T&gt;.TryCreateInstance()</c> so a consumer can register a
+    /// derived type with extra ambient fields; populate it through a <c>protected virtual</c> creation
+    /// hook on the mapper, not inline at each call site, so overriding it is a one-method change.
+    /// </summary>
+    public class MappingContext
+    {
+        public string CultureName { get; set; }
+    }
 }

--- a/src/VirtoCommerce.Xapi.Core/Models/MappingContext.cs
+++ b/src/VirtoCommerce.Xapi.Core/Models/MappingContext.cs
@@ -1,16 +1,15 @@
-namespace VirtoCommerce.Xapi.Core.Models
+namespace VirtoCommerce.Xapi.Core.Models;
+
+/// <summary>
+/// Base type for the ambient context objects X-module mappers take instead of positional
+/// parameters. A member belongs here only if it is the same for every item in the operation
+/// (e.g. culture, currency); per-item values derived from the caller's own iteration (e.g. an
+/// ordinal) do not belong on a context and should stay as separate arguments.
+/// Built via <c>AbstractTypeFactory&lt;T&gt;.TryCreateInstance()</c> so a consumer can register a
+/// derived type with extra ambient fields; populate it through a <c>protected virtual</c> creation
+/// hook on the mapper, not inline at each call site, so overriding it is a one-method change.
+/// </summary>
+public class MappingContext
 {
-    /// <summary>
-    /// Base type for the ambient context objects X-module mappers take instead of positional
-    /// parameters. A member belongs here only if it is the same for every item in the operation
-    /// (e.g. culture, currency); per-item values derived from the caller's own iteration (e.g. an
-    /// ordinal) do not belong on a context and should stay as separate arguments.
-    /// Built via <c>AbstractTypeFactory&lt;T&gt;.TryCreateInstance()</c> so a consumer can register a
-    /// derived type with extra ambient fields; populate it through a <c>protected virtual</c> creation
-    /// hook on the mapper, not inline at each call site, so overriding it is a one-method change.
-    /// </summary>
-    public class MappingContext
-    {
-        public string CultureName { get; set; }
-    }
+    public string CultureName { get; set; }
 }

--- a/src/VirtoCommerce.Xapi.Core/Models/MappingContext.cs
+++ b/src/VirtoCommerce.Xapi.Core/Models/MappingContext.cs
@@ -12,5 +12,13 @@ namespace VirtoCommerce.Xapi.Core.Models
     public abstract class MappingContext
     {
         public string CultureName { get; set; }
+
+        /// <summary>
+        /// The unresolved currency code. Every concern that needs currency shares this one
+        /// primitive spelling; a concern that needs a resolved <c>Currency</c> (or a store's
+        /// full currency set) keeps that resolved form on its own derived context instead of
+        /// re-declaring the code here.
+        /// </summary>
+        public string CurrencyCode { get; set; }
     }
 }

--- a/src/VirtoCommerce.Xapi.Core/Models/MappingContext.cs
+++ b/src/VirtoCommerce.Xapi.Core/Models/MappingContext.cs
@@ -1,0 +1,16 @@
+namespace VirtoCommerce.Xapi.Core.Models
+{
+    /// <summary>
+    /// Base type for the ambient context objects X-module mappers take instead of positional
+    /// parameters. A member belongs here only if it is the same for every item in the operation
+    /// (e.g. culture, currency); per-item values derived from the caller's own iteration (e.g. an
+    /// ordinal) do not belong on a context and should stay as separate arguments.
+    /// Built via <c>AbstractTypeFactory&lt;T&gt;.TryCreateInstance()</c> so a consumer can register a
+    /// derived type with extra ambient fields; populate it through a <c>protected virtual</c> creation
+    /// hook on the mapper, not inline at each call site, so overriding it is a one-method change.
+    /// </summary>
+    public class MappingContext
+    {
+        public string CultureName { get; set; }
+    }
+}

--- a/src/VirtoCommerce.Xapi.Core/Models/MappingContext.cs
+++ b/src/VirtoCommerce.Xapi.Core/Models/MappingContext.cs
@@ -9,7 +9,7 @@ namespace VirtoCommerce.Xapi.Core.Models
     /// derived type with extra ambient fields; populate it through a <c>protected virtual</c> creation
     /// hook on the mapper, not inline at each call site, so overriding it is a one-method change.
     /// </summary>
-    public class MappingContext
+    public abstract class MappingContext
     {
         public string CultureName { get; set; }
     }


### PR DESCRIPTION
## Description
Added FacetMappingContext (CultureName, Order) in VirtoCommerce.Xapi.Core.Models.Facets — an extensible context object for the cultureName/order parameters that ToFacetResult-style methods take across the X-modules. A caller builds it via AbstractTypeFactory<FacetMappingContext>.TryCreateInstance() and sets the fields it has; a future field can be added to the class without changing any ToFacetResult signature or breaking existing callers. No schema change, no migrations, no new settings, no new dependencies.

Companion PR: [VirtoCommerce/vc-module-x-catalog#110](https://github.com/VirtoCommerce/vc-module-x-catalog/pull/110) consumes this type in IXCatalogMapper.ToFacetResult.

## New GraphQL queries and mutations
None.

## Changes to existing GraphQL queries and mutations
None.

## New public services / interfaces / methods
FacetMappingContext — new public class, CultureName (string) and Order (int?) properties, no methods.

## New protected methods (extensibility)
None — a plain data-carrying context type, nothing to override.

## Breaking changes
None. Purely additive: no existing type, member, or signature changed.

## New dependencies
None.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5661
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Xapi_3.1020.0-alpha.203-vcst-5661.zip